### PR TITLE
Add ETL test

### DIFF
--- a/etl.py
+++ b/etl.py
@@ -1,0 +1,12 @@
+import json
+
+def run_etl(api_key, minio_client, etl_log, tmp_path):
+    import keepa
+    k = keepa.Keepa(api_key)
+    data = k.product_finder({'domainId': 1})
+    file_path = tmp_path / "data.json"
+    with open(file_path, "w") as f:
+        json.dump(data, f)
+    minio_client.fput_object("bucket", "data.json", str(file_path))
+    etl_log.insert({'file': str(file_path)})
+    return file_path

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,0 +1,30 @@
+import types
+import sys
+from etl import run_etl
+
+def test_run_etl(monkeypatch, tmp_path):
+    calls = {'n': 0}
+    class FakeKeepa:
+        def __init__(self, key):
+            pass
+        def product_finder(self, query):
+            calls['n'] += 1
+            return ['x']
+    keepa_module = types.SimpleNamespace(Keepa=FakeKeepa)
+    monkeypatch.setitem(sys.modules, 'keepa', keepa_module)
+    class FakeMinio:
+        def __init__(self):
+            self.path = None
+        def fput_object(self, bucket, name, path):
+            self.path = path
+    class FakeLog:
+        def __init__(self):
+            self.called = False
+        def insert(self, data):
+            self.called = True
+    minio_client = FakeMinio()
+    log = FakeLog()
+    file_path = run_etl('key', minio_client, log, tmp_path)
+    assert calls['n'] == 1
+    assert (tmp_path / file_path.name).exists()
+    assert log.called


### PR DESCRIPTION
## Summary
- implement `run_etl` helper that loads data using Keepa and stores file via Minio
- add pytest unit test to verify Keepa call, file output, and log insert

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632035b8ac8333bb86e0c691d72871