### PR TITLE
Add repricer service

### DIFF
--- a/services/repricer/repricer.py
+++ b/services/repricer/repricer.py
@@ -1,0 +1,30 @@
+import os
+import asyncio
+import asyncpg
+from sp_api.api import Listings
+
+query = """
+    SELECT offer_id, asin, target_min
+    FROM offers
+    WHERE buybox_price > target_min AND buybox_price < target_max
+"""
+
+async def main():
+    pool = await asyncpg.create_pool(os.environ["PG_DSN"])
+    rows = await pool.fetch(query)
+    listings = Listings(credentials={
+        "refresh_token": os.environ["SP_REFRESH_TOKEN"],
+        "lwa_app_id": os.environ["SP_CLIENT_ID"],
+        "lwa_client_secret": os.environ["SP_CLIENT_SECRET"],
+    })
+    for r in rows:
+        listings.pricing(asin=r["asin"], price=r["target_min"])
+        await pool.execute(
+            "INSERT INTO repricer_log (offer_id, new_price) VALUES ($1, $2)",
+            r["offer_id"],
+            r["target_min"],
+        )
+    await pool.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_repricer.py
+++ b/tests/test_repricer.py
@@ -1,0 +1,45 @@
+import types
+import sys
+import os
+import asyncio
+
+class FakePool:
+    def __init__(self):
+        self.log = []
+    async def fetch(self, query):
+        return [{"offer_id": 1, "asin": "ASIN1", "target_min": 10}]
+    async def execute(self, query, offer_id, price):
+        self.log.append((offer_id, price))
+    async def close(self):
+        pass
+
+class FakeListings:
+    def __init__(self, credentials):
+        self.calls = []
+    def pricing(self, asin, price):
+        self.calls.append((asin, price))
+
+pool = FakePool()
+async def fake_create_pool(dsn):
+    return pool
+
+class FakeSPModule:
+    def __init__(self):
+        self.instance = FakeListings(None)
+    def Listings(self, credentials):
+        return self.instance
+
+sys.modules['asyncpg'] = types.SimpleNamespace(create_pool=fake_create_pool)
+fake_sp = FakeSPModule()
+sys.modules['sp_api.api'] = fake_sp
+
+from services.repricer import repricer
+
+def test_main():
+    os.environ['PG_DSN'] = 'd'
+    os.environ['SP_REFRESH_TOKEN'] = 't'
+    os.environ['SP_CLIENT_ID'] = 'i'
+    os.environ['SP_CLIENT_SECRET'] = 's'
+    asyncio.run(repricer.main())
+    assert fake_sp.instance.calls == [('ASIN1', 10)]
+    assert pool.log == [(1, 10)]


### PR DESCRIPTION
## Summary
- implement hourly repricer script for Amazon listings
- add tests for repricer

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632075df388333bfef4473292d6f89