### PR TITLE
Add local docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,18 +6,34 @@ services:
       POSTGRES_PASSWORD: pass
     ports:
       - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
     networks:
       - awa-net
   minio:
     image: minio/minio
+    command: server /data --console-address :9001
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
     ports:
       - "9000:9000"
       - "9001:9001"
-    command: server /data --console-address :9001
+    volumes:
+      - miniodata:/data
     networks:
       - awa-net
+  etl:
+    build: ./services/etl
+    environment:
+      ENABLE_LIVE: "0"
+    depends_on:
+      - postgres
+      - minio
+    networks:
+      - awa-net
+volumes:
+  pgdata:
+  miniodata:
 networks:
   awa-net:


### PR DESCRIPTION
## Summary
- expand docker-compose for local development
  - add volumes for Postgres and Minio
  - add ETL service

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686325f5a85c8333bee14b72eac9f9e0