### PR TITLE
Add Dockerfile for repricer service

### DIFF
--- a/services/repricer/Dockerfile
+++ b/services/repricer/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python","repricer.py"]


### PR DESCRIPTION
## Summary
- add Dockerfile to containerize `services/repricer`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68632666b4b48333b9270259a18755f6