### PR TITLE
Add Dockerfile for ETL service

### DIFF
--- a/services/etl/Dockerfile
+++ b/services/etl/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python","keepa_ingestor.py"]


### PR DESCRIPTION
## Summary
- add a dedicated Dockerfile for the ETL service

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863262fc5ec83338418945b379dd827