### PR TITLE
Add SP fees ingestor

### DIFF
--- a/services/etl/requirements.txt
+++ b/services/etl/requirements.txt
@@ -1,3 +1,4 @@
 keepa==0.4.0
 minio==7.1.15
 psycopg2-binary==2.9.9
+python-amazon-sp-api==0.8.0

--- a/services/etl/sp_fees_ingestor.py
+++ b/services/etl/sp_fees_ingestor.py
@@ -1,0 +1,62 @@
+import os
+import json
+import psycopg2
+
+
+def main() -> int:
+    live = os.getenv("ENABLE_LIVE") == "1"
+    refresh_token = os.environ["SP_REFRESH_TOKEN"]
+    client_id = os.environ["SP_CLIENT_ID"]
+    client_secret = os.environ["SP_CLIENT_SECRET"]
+    seller_id = os.environ["SELLER_ID"]
+    region = os.environ["REGION"]
+    dsn = os.environ["PG_DSN"]
+    skus = ["DUMMY1", "DUMMY2"]
+    if live:
+        from sp_api.api import SellingPartnerAPI
+
+        api = SellingPartnerAPI(
+            refresh_token=refresh_token,
+            client_id=client_id,
+            client_secret=client_secret,
+            region=region,
+        )
+        results = []
+        for sku in skus:
+            r = api.get_my_fees_estimate_for_sku(sku)
+            amt = (
+                r["payload"]["FeesEstimateResult"]["FeesEstimate"]
+                ["TotalFeesEstimate"]["Amount"]
+            )
+            results.append((sku, amt))
+    else:
+        with open("tests/fixtures/spapi_fees_sample.json") as f:
+            data = json.load(f)
+        results = [
+            (
+                r["sku"],
+                r["payload"]["FeesEstimateResult"]["FeesEstimate"]["TotalFeesEstimate"]["Amount"],
+            )
+            for r in data
+        ]
+    conn = psycopg2.connect(dsn)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS fees_raw("
+        "sku text primary key, fee numeric, captured_at timestamptz default now())"
+    )
+    for sku, fee in results:
+        cur.execute(
+            "INSERT INTO fees_raw(sku, fee) VALUES (%s, %s) "
+            "ON CONFLICT (sku) DO UPDATE SET fee = EXCLUDED.fee",
+            (sku, fee),
+        )
+    conn.commit()
+    cur.close()
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/fixtures/spapi_fees_sample.json
+++ b/tests/fixtures/spapi_fees_sample.json
@@ -1,0 +1,26 @@
+[
+  {
+    "sku": "DUMMY1",
+    "payload": {
+      "FeesEstimateResult": {
+        "FeesEstimate": {
+          "TotalFeesEstimate": {
+            "Amount": 1.11
+          }
+        }
+      }
+    }
+  },
+  {
+    "sku": "DUMMY2",
+    "payload": {
+      "FeesEstimateResult": {
+        "FeesEstimate": {
+          "TotalFeesEstimate": {
+            "Amount": 2.22
+          }
+        }
+      }
+    }
+  }
+]

--- a/tests/test_sp_fees_ingestor.py
+++ b/tests/test_sp_fees_ingestor.py
@@ -1,0 +1,40 @@
+import os
+import types
+import sys
+
+class FakeCursor:
+    def __init__(self):
+        self.stmts = []
+    def execute(self, q, params=None):
+        self.stmts.append((q, params))
+    def close(self):
+        pass
+
+class FakeConn:
+    def __init__(self):
+        self.c = FakeCursor()
+    def cursor(self):
+        return self.c
+    def commit(self):
+        pass
+    def close(self):
+        pass
+
+def fake_connect(dsn):
+    return FakeConn()
+
+sys.modules['psycopg2'] = types.SimpleNamespace(connect=fake_connect)
+
+from services.etl import sp_fees_ingestor
+
+
+def test_offline(monkeypatch, tmp_path):
+    os.environ['ENABLE_LIVE'] = '0'
+    os.environ['SP_REFRESH_TOKEN'] = 't'
+    os.environ['SP_CLIENT_ID'] = 'i'
+    os.environ['SP_CLIENT_SECRET'] = 's'
+    os.environ['SELLER_ID'] = 'seller'
+    os.environ['REGION'] = 'EU'
+    os.environ['PG_DSN'] = 'dsn'
+    res = sp_fees_ingestor.main()
+    assert res == 0


### PR DESCRIPTION
## Summary
- add script for importing product fees via SP API
- include sample fee data fixture
- add offline unit test
- update ETL requirements

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632f9d295c83339c7325b404509158