### PR TITLE
Add helium fees test and module

### DIFF
--- a/services/etl/helium_fees.py
+++ b/services/etl/helium_fees.py
@@ -1,0 +1,38 @@
+import os
+import requests
+import psycopg2
+
+
+def main() -> int:
+    live = os.getenv("ENABLE_LIVE") == "1"
+    dsn = os.environ["PG_DSN"]
+    skus = ["DUMMY1", "DUMMY2"]
+    if live:
+        results = []
+        for sku in skus:
+            r = requests.get(f"https://example.com/{sku}")
+            r.raise_for_status()
+            data = r.json()
+            results.append((sku, data["fee"]))
+    else:
+        results = [("DUMMY1", 1.11), ("DUMMY2", 2.22)]
+    conn = psycopg2.connect(dsn)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS fees_raw("
+        "sku text primary key, fee numeric, captured_at timestamptz default now())"
+    )
+    for sku, fee in results:
+        cur.execute(
+            "INSERT INTO fees_raw(sku, fee) VALUES (%s, %s) "
+            "ON CONFLICT (sku) DO UPDATE SET fee = EXCLUDED.fee",
+            (sku, fee),
+        )
+    conn.commit()
+    cur.close()
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_helium_fees.py
+++ b/tests/test_helium_fees.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import requests
+
+
+class FakeCursor:
+    def __init__(self):
+        self.stmts = []
+    def execute(self, q, params=None):
+        self.stmts.append((q, params))
+    def close(self):
+        pass
+
+
+class FakeConn:
+    def __init__(self):
+        self.c = FakeCursor()
+    def cursor(self):
+        return self.c
+    def commit(self):
+        pass
+    def close(self):
+        pass
+
+
+connections = []
+
+def fake_connect(dsn):
+    conn = FakeConn()
+    connections.append(conn)
+    return conn
+
+
+calls = []
+
+def fake_get(url):
+    calls.append(url)
+    return types.SimpleNamespace(json=lambda: {"fee": 0}, raise_for_status=lambda: None)
+
+
+def test_offline(monkeypatch):
+    monkeypatch.setattr(requests, 'get', fake_get)
+    monkeypatch.setitem(sys.modules, 'psycopg2', types.SimpleNamespace(connect=fake_connect))
+    os.environ.pop('ENABLE_LIVE', None)
+    os.environ['PG_DSN'] = 'dsn'
+    from services.etl import helium_fees
+    res = helium_fees.main()
+    inserts = [s for s in connections[0].c.stmts if s[0].startswith('INSERT INTO fees_raw')]
+    assert res == 0
+    assert calls == []
+    assert [p for q, p in inserts] == [('DUMMY1', 1.11), ('DUMMY2', 2.22)]


### PR DESCRIPTION
## Summary
- implement a simple helium_fees ETL module
- add pytest covering offline run with mocked HTTP and database

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686332e19c2083339116d91382960a7c