### PR TITLE
Add pre-commit black hook and enforce formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
                       pytest ruff black mypy
 
       - run: ruff check .
-      - run: black --check .
+      - run: black .
+      - run: git diff --exit-code
       - run: mypy services || true
       - run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# AWA App
+
+## Development setup
+
+### Code style
+```bash
+pip install pre-commit
+pre-commit install
+```
+Black auto-formats every commit; CI enforces `git diff --exit-code`.
+


### PR DESCRIPTION
## Summary
- add Black hook for pre-commit
- enforce formatting in CI
- document code style setup

## Testing
- `ruff check .`
- `black . --check`
- `mypy services || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bdca686c8333b08f8ce621d2f869