### PR TITLE
Add minimal webapp setup

### DIFF
--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -1,0 +1,1 @@
+module.exports = { reactStrictMode: true, experimental: { typedRoutes: true } }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "webapp",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint --fix"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "19.0.0-rc",
+    "react-dom": "19.0.0-rc",
+    "typescript": "*",
+    "tailwindcss": "*",
+    "lucide-react": "*",
+    "@shadcn/ui": "*"
+  }
+}

--- a/webapp/tailwind.config.js
+++ b/webapp/tailwind.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: [require('@shadcn/ui/preset')],
+  darkMode: 'class'
+}


### PR DESCRIPTION
## Summary
- set up a basic Next.js 14 webapp
- include shadcn/ui tailwind preset with dark mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68642531d1008333833e373c0ac0ae92