### PR TITLE
Add shadcn UI components

### DIFF
--- a/webapp/components/DataTable.tsx
+++ b/webapp/components/DataTable.tsx
@@ -1,37 +1,48 @@
-'use client';
+'use client'
 
-import { useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from './ui/table'
+import StatBadge from './StatBadge'
 
 export interface DataItem {
-  asin: string;
-  title: string;
-  roi: number;
+  asin: string
+  title: string
+  roi: number
 }
 
 export function DataTable({ data }: { data: DataItem[] }) {
-  const router = useRouter();
+  const router = useRouter()
   return (
-    <table className="w-full text-sm">
-      <thead>
-        <tr>
-          <th className="text-left p-2">ASIN</th>
-          <th className="text-left p-2">Title</th>
-          <th className="text-left p-2">ROI</th>
-        </tr>
-      </thead>
-      <tbody>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>ASIN</TableHead>
+          <TableHead>Title</TableHead>
+          <TableHead>ROI</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {data.map((item) => (
-          <tr
+          <TableRow
             key={item.asin}
-            className="cursor-pointer hover:bg-accent"
+            className="cursor-pointer"
             onClick={() => router.push(`/sku/${item.asin}`)}
           >
-            <td className="p-2">{item.asin}</td>
-            <td className="p-2">{item.title}</td>
-            <td className="p-2">{item.roi}</td>
-          </tr>
+            <TableCell>{item.asin}</TableCell>
+            <TableCell>{item.title}</TableCell>
+            <TableCell>
+              <StatBadge roi={item.roi} />
+            </TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
-  );
+      </TableBody>
+    </Table>
+  )
 }

--- a/webapp/components/Sidebar.tsx
+++ b/webapp/components/Sidebar.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function Sidebar() {
+  return (
+    <aside className="w-48 border-r min-h-screen p-4">
+      <nav className="space-y-2">
+        <Link href="/" className="block rounded px-3 py-2 hover:bg-accent">
+          Dashboard
+        </Link>
+        <Link href="/health" className="block rounded px-3 py-2 hover:bg-accent">
+          Health
+        </Link>
+      </nav>
+    </aside>
+  )
+}

--- a/webapp/components/StatBadge.tsx
+++ b/webapp/components/StatBadge.tsx
@@ -1,0 +1,10 @@
+interface StatBadgeProps {
+  roi: number
+}
+
+export default function StatBadge({ roi }: StatBadgeProps) {
+  const color = roi >= 0 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+  return (
+    <span className={`rounded-md px-2 py-1 text-xs font-medium ${color}`}>{roi}%</span>
+  )
+}

--- a/webapp/components/ui/table.tsx
+++ b/webapp/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = 'Table'
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+))
+TableHeader.displayName = 'TableHeader'
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+))
+TableBody.displayName = 'TableBody'
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = 'TableFooter'
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = 'TableRow'
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = 'TableHead'
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = 'TableCell'
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+TableCaption.displayName = 'TableCaption'
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/webapp/lib/utils.ts
+++ b/webapp/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- implement `DataTable` as a shadcn table wrapper
- add `StatBadge` for colored ROI display
- add `Sidebar` navigation component
- include shadcn `Table` component and small `cn` util

## Testing
- `pre-commit run --files webapp/components/DataTable.tsx webapp/components/StatBadge.tsx webapp/components/Sidebar.tsx webapp/components/ui/table.tsx webapp/lib/utils.ts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642d0974f483338b1f634d9489bea6