### PR TITLE
Add web service Dockerfile and compose entry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,16 @@ services:
       - minio
     networks:
       - awa-net
+  web:
+    build: ./webapp
+    environment:
+      NEXT_PUBLIC_API_URL: http://api:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api
+    networks:
+      - awa-net
 volumes:
   pgdata:
   miniodata:

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY . .
+RUN npm run build
+CMD ["npm","start"]


### PR DESCRIPTION
## Summary
- build a Next.js web container
- wire the new `web` service into docker-compose

## Testing
- `pre-commit run --files docker-compose.yml webapp/Dockerfile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642f199b488333a51b88c0abfe7ccb