### PR TITLE
Add Playwright dashboard test handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,34 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=5
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+
+      - name: Detect sandbox
+        run: |
+          if [[ "$GITHUB_ACTIONS" != "true" ]]; then
+            echo "PLAYWRIGHT_OFFLINE=1" >> $GITHUB_ENV
+          fi
+
       - run: |
-          pip install -r services/etl/requirements.txt \
-                      -r services/api/requirements.txt \
-                      -r services/repricer/requirements.txt \
-                      pytest ruff black mypy
+          pip install -r services/etl/requirements.txt
+          pip install -r services/api/requirements.txt
+          pip install -r services/repricer/requirements.txt
+          pip install pytest ruff black mypy
+
+      - if: env.PLAYWRIGHT_OFFLINE != '1'
+        run: |
+          npm install -g playwright
+          playwright install --with-deps chromium
 
       - run: ruff check .
-      - run: black .
-      - run: git diff --exit-code
+      - run: black --check .
       - run: mypy services || true
       - run: pytest -q

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import time
+
+from urllib import request
+from playwright.sync_api import sync_playwright
+import pytest
+
+if os.getenv("PLAYWRIGHT_OFFLINE") == "1":
+    pytest.skip("Playwright disabled in offline CI", allow_module_level=True)
+
+
+def wait_for_server(url: str, timeout: int = 30) -> None:
+    for _ in range(timeout):
+        try:
+            with request.urlopen(url) as resp:  # noqa: S310
+                if resp.status < 500:
+                    return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError("server did not start")
+
+
+def test_dashboard_local_compose():
+    subprocess.run(["docker", "compose", "up", "-d"], check=True)
+    try:
+        wait_for_server("http://localhost:3000")
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.goto("http://localhost:3000/")
+            assert page.title() is not None
+            browser.close()
+    finally:
+        subprocess.run(["docker", "compose", "down"], check=False)


### PR DESCRIPTION
## Summary
- skip Playwright dashboard test when offline
- install Playwright browsers in CI and run tests with optional skip
- fix CI workflow YAML syntax

## Testing
- `pre-commit run --files tests/test_dashboard.py .github/workflows/ci.yml` *(fails: command not found)*
- `PLAYWRIGHT_OFFLINE=1 pytest -q` *(fails: docker not available)*


------
https://chatgpt.com/codex/tasks/task_e_686430a43bf0833387cd7f32bf0216b2