### PR TITLE
Fix YAML formatting of Postgres service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,8 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+          --health-cmd="pg_isready" --health-interval=10s
+          --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- fix multiline options block for postgres service in CI workflow

## Testing
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68643c0cdb048333b736a14a8760fca3