### PR TITLE
Fix webapp Dockerfile

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+COPY package.json ./
+RUN npm install --omit=dev
 COPY . .
 RUN npm run build
 CMD ["npm","start"]


### PR DESCRIPTION
## Summary
- update Dockerfile to use `npm install --omit=dev`
- stop copying package-lock.json

## Testing
- `docker compose build web` *(fails: `docker: command not found`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686448d6b3b48333b6e2861af21ad37c