### PR TITLE
Fix web healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,11 @@ services:
       NEXT_PUBLIC_API_URL: http://api:8000
     ports:
       - "3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
     depends_on:
       - api
     networks:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -31,9 +31,8 @@ def wait_for_server(url: str, timeout: int = 60) -> None:
 
 
 def test_dashboard_local_compose():
-    subprocess.run(["docker", "compose", "up", "-d"], check=True)
+    subprocess.check_call("docker compose up -d --wait --wait-timeout 120", shell=True)
     try:
-        wait_for_server("http://localhost:3000")
         with sync_playwright() as p:
             try:
                 browser = p.chromium.launch()

--- a/webapp/app/health/page.tsx
+++ b/webapp/app/health/page.tsx
@@ -1,0 +1,4 @@
+export const dynamic = 'force-dynamic'
+export default function Health() {
+  return <div>ok</div>
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3000 -H 0.0.0.0",
     "lint": "eslint --fix"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- expose web health endpoint and add Docker healthcheck
- adjust Next.js start script
- run docker compose up with wait in dashboard test

## Testing
- `ruff check .`
- `black --check .`
- `mypy services || true`
- `pytest -q`
- `docker compose build web` *(fails: command not found)*
- `docker compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646b7b7e34833388e04a9976091e3b