### PR TITLE
Fix tests failing due to missing httpx and docker

### DIFF
--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.110.0
 uvicorn==0.29.0
 aiosqlite~=0.19.0
+httpx==0.27.0

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4,8 +4,8 @@ import time
 import requests
 import pytest
 
-if shutil.which("docker") is None:
-    pytest.skip("Docker not available in this runtime", allow_module_level=True)
+if shutil.which("docker") is None or shutil.which("docker-compose") is None:
+    pytest.skip("Docker is not installed on this runner", allow_module_level=True)
 
 
 def test_compose_up() -> None:


### PR DESCRIPTION
## Summary
- add httpx for FastAPI tests
- skip dashboard tests when docker-compose is missing

## Testing
- `ruff check .`
- `black --check .`
- `mypy services`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865351ebd408333bcb7ad6ef649f671