### PR TITLE
Fix Postgres compose in CI

### DIFF
--- a/.env.postgres
+++ b/.env.postgres
@@ -1,2 +1,5 @@
 DATABASE_URL=postgresql+asyncpg://awa:awa@postgres:5432/awa
 ENABLE_LIVE=1
+MINIO_ACCESS_KEY=minio
+MINIO_SECRET_KEY=minio123
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,13 @@ jobs:
           pip install -r services/api/requirements.txt
           pip install -r services/repricer/requirements.txt
           pip install pytest ruff black mypy
-      - run: docker compose -f docker-compose.postgres.yml up -d --wait
+      - name: Copy env (Postgres)
+        run: cp .env.postgres .env
+      - name: Compose up (Postgres)
+        run: docker compose \
+               -f docker-compose.yml \
+               -f docker-compose.postgres.yml \
+               up -d --wait
       - run: ruff check .
       - run: black --check .
       - run: mypy services || true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ export DATABASE_URL="postgresql+asyncpg://awa:awa@postgres:5432/awa"
 SQLite remains the default for local development. To run with Postgres just run:
 
 ```bash
-docker compose -f docker-compose.postgres.yml up -d --wait
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d --wait
 ```
 
 Then visit `http://localhost:8000/health`.


### PR DESCRIPTION
## Summary
- update workflow to combine compose files for Postgres stack
- include Postgres env file so compose env_file resolves
- document proper compose command in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy services || true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686555f4ab6c83339fc9cc777c7a4c41