### PR TITLE
Fix root .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Byte-compiled / optimized files
+__pycache__
+*.py[cod]
+*.so
+
+# Packaging artifacts
+*.egg-info
+
+# Version control
+.git
+
+# Virtual environments
+.venv
+
+# Node dependencies
+**/node_modules
+
+# Env / secrets
+.env
+
+# End of file


### PR DESCRIPTION
## Summary
- add `.dockerignore` at repo root so Docker build context is sane

## Testing
- `ruff check .`
- `black --check .`
- `mypy services`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68655e9b5ae883338cbd089af947f89d