### PR TITLE
Fix compose build contexts

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -14,7 +14,6 @@ services:
       - awa-pgdata:/var/lib/postgresql/data
 
   api:
-    build: ./services/api
     depends_on: [postgres]
     environment:
       - DATABASE_URL=${DATABASE_URL}
@@ -27,7 +26,6 @@ services:
       - .env.postgres
 
   repricer:
-    build: ./services/repricer
     env_file:
       - .env.postgres
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       - awa-net
   api:
     build:
-      context: .
-      dockerfile: services/api/Dockerfile
+      context: ./services/api
     env_file:
       - .env.example
     ports:
@@ -30,7 +29,8 @@ services:
     volumes:
       - awa-data:/data
   etl:
-    build: ./services/etl
+    build:
+      context: ./services/etl
     env_file:
       - .env.example
     depends_on:


### PR DESCRIPTION
## Summary
- use explicit build contexts in docker-compose.yml
- strip redundant build lines from postgres override

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68657a70e7f88333b1bbc7c7893c902c