### PR TITLE
Fix repricer sp-api requirement

### DIFF
--- a/services/repricer/requirements.txt
+++ b/services/repricer/requirements.txt
@@ -1,4 +1,7 @@
+# ---------------- Core stack ---------------- #
 fastapi==0.110.0
 uvicorn==0.29.0
-python-sp-api==0.9.0
 pydantic-settings==2.2.1
+
+# -------- Amazon Selling Partner API -------- #
+python-amazon-sp-api==0.8.0       # align with ETL; real package name


### PR DESCRIPTION
## Summary
- fix the package name in `services/repricer/requirements.txt`

## Testing
- `pytest -q`
- `docker compose build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6865bdd3cf848333bb9034bd1e29f628