### PR TITLE
Fix postgres compose override

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -26,8 +26,15 @@ services:
       - .env.postgres
 
   repricer:
+    build:
+      context: ./services/repricer
     env_file:
       - .env.postgres
+    depends_on:
+      api:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
 
 volumes:
   awa-pgdata:


### PR DESCRIPTION
## Summary
- update the postgres override so `repricer` has a build context

## Testing
- `pip install -r services/api/requirements.txt -r services/repricer/requirements.txt -r services/etl/requirements.txt requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c219fe9083339d5b9840ead2695e