### PR TITLE
Fix black formatting for tests/test_api.py

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ def _port_open(host: str, port: int) -> bool:
     except OSError:
         return False
 
+
 @pytest.mark.asyncio
 async def test_health_ok():
     if not _port_open("localhost", 8000):


### PR DESCRIPTION
## Summary
- format tests/test_api.py with `black` to satisfy pre-commit check

## Testing
- `pre-commit run --files tests/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6866faa4e70c8333bd24298868665edb