### PR TITLE
Fix API start-up by waiting for Postgres health

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -14,7 +14,9 @@ services:
       - awa-pgdata:/var/lib/postgresql/data
 
   api:
-    depends_on: [postgres]
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
       - DATABASE_URL=${DATABASE_URL}
 


### PR DESCRIPTION
## Summary
- wait for postgres health before starting API container in docker-compose.postgres.yml

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686798bbdf948333b36ac6723f46c449