### PR TITLE
Fix API module import

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -3,7 +3,7 @@ import asyncio
 from fastapi import FastAPI
 from sqlalchemy import text, bindparam
 
-from .db import AsyncSession
+from db import AsyncSession
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- fix relative import in `services/api/main.py` to allow app startup

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b7e245f48333b58e9f54756e3e4f