### PR TITLE
Fix Postgres compose start

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -13,6 +13,8 @@ app = FastAPI()
 
 @app.on_event("startup")
 async def _wait_for_db() -> None:
+    """Block application startup until the database becomes available."""
+    delay = 0.3
     for _ in range(10):
         try:
             async for session in get_session():
@@ -20,7 +22,8 @@ async def _wait_for_db() -> None:
             subprocess.run(["alembic", "upgrade", "head"], check=True)
             return
         except Exception:
-            await asyncio.sleep(2)
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 3)
     raise RuntimeError("Database not available")
 
 

--- a/tests/test_helium_fees.py
+++ b/tests/test_helium_fees.py
@@ -31,7 +31,7 @@ class FakeConn:
 
 def test_offline(monkeypatch):
     os.environ.pop("ENABLE_LIVE", None)
-    os.environ["DATABASE_URL"] = "d"
+    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "d")
     called = {"n": 0}
 
     def fake_get(url):

--- a/tests/test_helium_fees_ingestor.py
+++ b/tests/test_helium_fees_ingestor.py
@@ -38,6 +38,6 @@ sys.modules["psycopg2"].connect = fake_connect
 def test_offline(monkeypatch):
     os.environ["ENABLE_LIVE"] = "0"
     os.environ["HELIUM_API_KEY"] = "k"
-    os.environ["DATABASE_URL"] = "dsn"
+    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "dsn")
     res = helium_fees_ingestor.main()
     assert res == 0

--- a/tests/test_sp_fees.py
+++ b/tests/test_sp_fees.py
@@ -38,7 +38,7 @@ class FakeSP:
 
 def test_main_offline(monkeypatch):
     os.environ.pop("ENABLE_LIVE", None)
-    os.environ["DATABASE_URL"] = "d"
+    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "d")
     fake_api = FakeSP()
     monkeypatch.setitem(
         sys.modules,

--- a/tests/test_sp_fees_ingestor.py
+++ b/tests/test_sp_fees_ingestor.py
@@ -42,6 +42,6 @@ def test_offline(monkeypatch, tmp_path):
     os.environ["SP_CLIENT_SECRET"] = "s"
     os.environ["SELLER_ID"] = "seller"
     os.environ["REGION"] = "EU"
-    os.environ["DATABASE_URL"] = "dsn"
+    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "dsn")
     res = sp_fees_ingestor.main()
     assert res == 0


### PR DESCRIPTION
## Summary
- add an exponential backoff wait on API startup
- read DATABASE_URL from env in tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867c8ef65e08333bf41cea85eaf59ec