### PR TITLE
fix(api): make FastAPI boot reliably with Postgres in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
             -f docker-compose.yml \
             -f docker-compose.postgres.yml \
             up -d --wait
+      - run: docker compose logs api --tail=100
       - run: ruff check .
       - run: black --check .
       - run: mypy services || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,15 @@ services:
       - awa-net
   api:
     build:
-      context: ./services/api
+      context: .
+      dockerfile: services/api/Dockerfile
     env_file:
       - .env.example
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+    depends_on:
+      postgres:
+        condition: service_healthy
     ports:
       - "8000:8000"
     healthcheck:

--- a/scripts/wait_for_db.py
+++ b/scripts/wait_for_db.py
@@ -1,0 +1,26 @@
+import asyncio
+import os
+import sys
+import subprocess
+import asyncpg
+
+
+async def wait_for_db(url: str) -> None:
+    delay = 0.3
+    for _ in range(10):
+        try:
+            conn = await asyncpg.connect(url)
+            await conn.execute("SELECT 1")
+            await conn.close()
+            subprocess.run(["alembic", "upgrade", "head"], check=True)
+            return
+        except Exception:
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 3)
+    raise RuntimeError("Database not available")
+
+
+if __name__ == "__main__":
+    dsn = os.environ.get("DATABASE_URL")
+    asyncio.run(wait_for_db(dsn))
+    os.execvp(sys.argv[1], sys.argv[1:])

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+COPY ../../scripts/wait_for_db.py /wait_for_db.py
+
 COPY . .
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "/wait_for_db.py", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -1,6 +1,5 @@
 from typing import List
 import asyncio
-import subprocess
 from fastapi import Depends, FastAPI
 from sqlalchemy import bindparam, text
 
@@ -19,7 +18,6 @@ async def _wait_for_db() -> None:
         try:
             async for session in get_session():
                 await session.execute(text("SELECT 1"))
-            subprocess.run(["alembic", "upgrade", "head"], check=True)
             return
         except Exception:
             await asyncio.sleep(delay)

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.110.0
 uvicorn==0.29.0
 asyncpg>=0.29            # async Postgres driver
-psycopg[binary]==3.1.*   # sync driver for Alembic CLI
+psycopg[binary]==3.*     # sync driver for Alembic CLI
+alembic==1.*             # migrations
 httpx==0.27.0            # used in tests
 sqlalchemy>=2.0,<2.1    # core ORM/DB driver

--- a/tests/test_api_live.py
+++ b/tests/test_api_live.py
@@ -1,0 +1,27 @@
+import os
+import time
+import socket
+import requests
+import pytest
+
+
+def _port_open(host: str, port: int) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(not _port_open("localhost", 8000), reason="api not running")
+def test_api_live_health() -> None:
+    url = os.getenv("NEXT_PUBLIC_API_URL", "http://localhost:8000") + "/health"
+    for _ in range(10):
+        try:
+            r = requests.get(url, timeout=0.5)
+            if r.status_code == 200 and r.json() == {"db": "ok"}:
+                return
+        except Exception:
+            pass
+        time.sleep(0.5)
+    raise AssertionError("API did not respond with healthy status")


### PR DESCRIPTION
## Summary
- ensure Alembic is installed and use helper script to wait for Postgres
- build api image from project root and run wait_for_db.py before uvicorn
- set DATABASE_URL via compose and wait for healthy postgres
- print api logs on CI failures
- add regression test checking live api

## Testing
- `ruff check .`
- `black --check .`
- `mypy services || true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867d48eda848333a5a5516a88016d15