### PR TITLE
Fix API Dockerfile path

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -2,10 +2,13 @@
 FROM python:3.11-slim AS base
 
 WORKDIR /app
-COPY requirements.txt .
+# Install API dependencies
+COPY services/api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ../../scripts/wait_for_db.py /wait_for_db.py
+# Copy helper script for database readiness and migrations
+COPY scripts/wait_for_db.py /wait_for_db.py
 
-COPY . .
+# Copy application source
+COPY services/api .
 CMD ["python", "/wait_for_db.py", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.110.0
 uvicorn==0.29.0
-asyncpg>=0.29            # async Postgres driver
-psycopg[binary]==3.*     # sync driver for Alembic CLI
-alembic==1.*             # migrations
-httpx==0.27.0            # used in tests
-sqlalchemy>=2.0,<2.1    # core ORM/DB driver
+asyncpg==0.30.0
+psycopg[binary]==3.*
+alembic==1.*
+httpx==0.27.0
+sqlalchemy>=2.0,<2.1


### PR DESCRIPTION
## Summary
- install API deps from the service folder
- include wait-for-db script
- use pinned API requirements

## Testing
- `ruff check .`
- `black --check .`
- `mypy services || true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867d807b9908333a1095d8855361831