### PR TITLE
Fix /score query table name

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -36,7 +36,7 @@ async def score(asins: List[str], session: AsyncSession = Depends(get_session)):
     query = text(
         """
         SELECT p.asin, (p.price - o.cost) / o.cost AS roi
-        FROM product p
+        FROM products p
         JOIN offers o ON p.asin = o.asin
         WHERE p.asin IN :asins
         ORDER BY roi DESC


### PR DESCRIPTION
## Summary
- fix table name in /score endpoint to use plural `products`

## Testing
- `ruff check .`
- `black --check .`
- `mypy services || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e5cbda388333b7567c6ef8b93c42