### PR TITLE
Fix API container start-up with entrypoint wait

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -37,7 +37,7 @@ services:
     env_file:
       - .env.example
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: postgresql+psycopg://root:pass@postgres:5432/awa
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -7,14 +7,12 @@ COPY services/api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy wait helper
-COPY scripts/wait-for.sh /wait-for.sh
-RUN chmod +x /wait-for.sh
-
-# Copy helper script for database readiness and migrations
-COPY scripts/wait_for_db.py /wait_for_db.py
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Copy application source
-COPY services/api .
+COPY services/api /app/services/api
+COPY config.py /app/config.py
+COPY alembic.ini /app/alembic.ini
 
-ENTRYPOINT ["/wait-for.sh", "postgres:5432"]
-CMD ["python", "/wait_for_db.py", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/services/api/docker-entrypoint.sh
+++ b/services/api/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+url="${DATABASE_URL}"
+if [ -z "$url" ]; then
+  echo "DATABASE_URL not set" >&2
+  exit 1
+fi
+
+read host port <<PYEOF
+$(python - <<'PY'
+import os, urllib.parse
+u=os.environ['DATABASE_URL']
+u=u.replace('postgresql+asyncpg://','postgresql://').replace('postgresql+psycopg://','postgresql://')
+parsed=urllib.parse.urlparse(u)
+print(parsed.hostname)
+print(parsed.port or 5432)
+PY
+)
+PYEOF
+
+delay=1
+elapsed=0
+while ! pg_isready -h "$host" -p "$port" >/dev/null 2>&1; do
+  sleep "$delay"
+  elapsed=$((elapsed + delay))
+  if [ $elapsed -ge 30 ]; then
+    echo "Database not reachable after ${elapsed}s" >&2
+    exit 1
+  fi
+  if [ $delay -lt 8 ]; then
+    delay=$((delay * 2))
+  fi
+done
+
+alembic upgrade head
+exec uvicorn services.api.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- replace build-time migration with runtime `docker-entrypoint.sh`
- copy config and migrations into the API image
- set DATABASE_URL in `docker-compose.postgres.yml` for the API service

## Testing
- `pip install -r services/etl/requirements.txt -r services/api/requirements.txt -r services/repricer/requirements.txt -r requirements-dev.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ee36e0e083338e716a55286c1d2f