### PR TITLE
Fix API Dockerfile entrypoint path

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -7,7 +7,7 @@ COPY services/api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy wait helper
-COPY docker-entrypoint.sh /entrypoint.sh
+COPY services/api/docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Copy application source


### PR DESCRIPTION
## Summary
- ensure docker-entrypoint script is copied from the correct location

## Testing
- `pre-commit run --files services/api/Dockerfile`
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*
- `docker compose build api` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f2d26620833387c96a0c6e811962