### PR TITLE
Audit Postgres profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,7 @@ services:
       context: .
       dockerfile: services/api/Dockerfile
     env_file:
-      - .env.example
-    environment:
-      DATABASE_URL: ${DATABASE_URL}
+      - .env.postgres
     depends_on:
       postgres:
         condition: service_healthy
@@ -38,7 +36,7 @@ services:
     build:
       context: ./services/etl
     env_file:
-      - .env.example
+      - .env.postgres
     depends_on:
       - minio
     healthcheck:
@@ -72,7 +70,7 @@ services:
       interval: 10s
       retries: 5
     env_file:
-      - .env.example
+      - .env.postgres
     depends_on:
       api:
         condition: service_healthy

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -6,13 +6,13 @@ WORKDIR /app
 COPY services/api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy wait helper
-COPY services/api/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# Copy entrypoint
+COPY services/api/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 # Copy application source
 COPY services/api /app/services/api
 COPY config.py /app/config.py
 COPY alembic.ini /app/alembic.ini
 
-CMD ["/entrypoint.sh"]
+CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- use docker-entrypoint in the API image
- load `.env.postgres` consistently for python services

## Testing
- `ruff check .`
- `black --check .`
- `mypy services >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest -q`
- `docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d --build --wait` *(fails: `docker` not found)*
- `curl -f http://localhost:8000/health` *(fails: connection refused)*
- `docker compose ps` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868110ce1c08333b8dc5d4fe4bbf9c8