### PR TITLE
Fix invalid expressions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DATA_DIR: ${{ runner.temp }}/awa-data
+      DATA_DIR: "${{ runner.temp }}/awa-data"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -50,7 +50,7 @@ jobs:
       PG_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
       PG_DATABASE: ${{ env.POSTGRES_DB }}
       PG_HOST: localhost
-      DATA_DIR: ${{ runner.temp }}/awa-data
+      DATA_DIR: "${{ runner.temp }}/awa-data"
     services:
       postgres:
         image: postgres:15


### PR DESCRIPTION
## Summary
- fix up references to `runner.temp` in CI workflow

## Testing
- `act -W .github/workflows -j build` *(fails: couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_686f02f6e6cc8333a2dc1b7d7015ba6b