### PR TITLE
Fix CI dependency install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+
+          # install global dev reqs first
           pip install -r requirements-dev.txt
+
+          # then recursively install every service / sub-module requirements
+          find . -type f -name "requirements*.txt" ! -path "./requirements-dev.txt" \
+            -print0 | while IFS= read -r -d '' reqfile; do
+              echo "Installing $reqfile"
+              pip install -r "$reqfile"
+            done
       - run: ruff check .
       - run: black --check .
       - run: mypy services || true
@@ -143,8 +151,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+
+          # install global dev reqs first
           pip install -r requirements-dev.txt
+
+          # then recursively install every service / sub-module requirements
+          find . -type f -name "requirements*.txt" ! -path "./requirements-dev.txt" \
+            -print0 | while IFS= read -r -d '' reqfile; do
+              echo "Installing $reqfile"
+              pip install -r "$reqfile"
+            done
       - run: docker build -t price_importer services/price_importer
       - name: Wait for Postgres
         run: |


### PR DESCRIPTION
## Summary
- install dependencies from requirements-dev.txt then recursively install all other requirements files in CI
- use one loop for service-level requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f27693e6083339947bb8439a71f65