### PR TITLE
Fix workflow tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v3
         with:
-          path: ${{runner.temp}}/pip-cache
+          path: ~/.cache/pip
           key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
           restore-keys: |
             ${{runner.os}}-pip-
@@ -73,7 +73,7 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v3
         with:
-          path: ${{runner.temp}}/pip-cache
+          path: ~/.cache/pip
           key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
           restore-keys: |
             ${{runner.os}}-pip-
@@ -141,7 +141,7 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v3
         with:
-          path: ${{runner.temp}}/pip-cache
+          path: ~/.cache/pip
           key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
           restore-keys: |
             ${{runner.os}}-pip-


### PR DESCRIPTION
## Summary
- avoid bare tokens in ci.yml by using a static pip cache path

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f6731a2c83338d30ed3e6681e61b