### PR TITLE
Fix env and runner references in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DATA_DIR: ${{runner.temp}}/awa-data
+      DATA_DIR: ${{ runner.temp }}/awa-data
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: pass # pragma: allowlist secret
       PG_DATABASE: awa
@@ -25,9 +25,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
-            ${{runner.os}}-pip-
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -49,10 +49,10 @@ jobs:
       POSTGRES_PASSWORD: pass # pragma: allowlist secret
       POSTGRES_DB: awa
       PG_DATABASE: awa
-      PG_USER: ${{env.POSTGRES_USER}}
-      PG_PASSWORD: ${{env.POSTGRES_PASSWORD}}
+      PG_USER: postgres
+      PG_PASSWORD: pass # pragma: allowlist secret
       PG_HOST: localhost
-      DATA_DIR: ${{runner.temp}}/awa-data
+      DATA_DIR: ${{ runner.temp }}/awa-data
     services:
       postgres:
         image: postgres:15
@@ -74,9 +74,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
-            ${{runner.os}}-pip-
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -142,9 +142,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
-            ${{runner.os}}-pip-
+            ${{ runner.os }}-pip-
       - name: Install all Python requirements
         run: |
           python -m pip install --upgrade pip
@@ -163,9 +163,9 @@ jobs:
           PGPASSWORD: pass # pragma: allowlist secret
       - run: alembic upgrade head
         env:
-          PG_USER: ${{env.POSTGRES_USER}}
-          PG_PASSWORD: ${{env.POSTGRES_PASSWORD}}
-          PG_DATABASE: ${{env.PG_DATABASE}}
+          PG_USER: postgres
+          PG_PASSWORD: pass # pragma: allowlist secret
+          PG_DATABASE: awa
           PG_HOST: localhost
       - run: |
           docker run --network host \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     services:
       postgres:
         image: postgres:15
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pass
-          POSTGRES_DB: awa
-        ports: ['5432:5432']
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: pass # pragma: allowlist secret
+            POSTGRES_DB: awa
+          ports: ['5432:5432']
         options: >-
           --health-cmd="pg_isready -U postgres -d awa"
           --health-interval=5s
@@ -44,34 +44,34 @@ jobs:
           done
           echo "::error::Postgres never became ready"
           exit 1
-        env:
-          PGPASSWORD: pass
-        shell: bash
+          env:
+            PGPASSWORD: pass # pragma: allowlist secret
+          shell: bash
 
       - name: Run Alembic migrations
         run: alembic upgrade head
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pass
-          POSTGRES_DB: awa
-          PG_USER: ${{ env.POSTGRES_USER }}
-          PG_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
-          PG_DATABASE: ${{ env.POSTGRES_DB }}
-          PG_HOST: localhost
-          PG_PORT: '5432'
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: pass # pragma: allowlist secret
+            POSTGRES_DB: awa
+            PG_USER: postgres
+            PG_PASSWORD: pass # pragma: allowlist secret
+            PG_DATABASE: awa
+            PG_HOST: localhost
+            PG_PORT: '5432'
 
       - name: pytest -q
         run: pytest -q
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pass
-          POSTGRES_DB: awa
-          PG_USER: ${{ env.POSTGRES_USER }}
-          PG_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
-          PG_DATABASE: ${{ env.POSTGRES_DB }}
-          PG_HOST: localhost
-          PG_PORT: '5432'
-          DATA_DIR: ${{ runner.temp }}/awa-data
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: pass # pragma: allowlist secret
+            POSTGRES_DB: awa
+            PG_USER: postgres
+            PG_PASSWORD: pass # pragma: allowlist secret
+            PG_DATABASE: awa
+            PG_HOST: localhost
+            PG_PORT: '5432'
+            DATA_DIR: ${{ runner.temp }}/awa-data
 
       - name: Dump Postgres logs
         if: always()


### PR DESCRIPTION
## Summary
- fix test workflow env tokens
- style runner context spacing in CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/test.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68710229c6748333abbc29b9f70461d2