### PR TITLE
Fix YAML syntax in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATA_DIR: ${{runner.temp}}/awa-data
-      DATA_DIR: $RUNNER_TEMP/awa-data
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: pass # pragma: allowlist secret
       PG_DATABASE: awa
@@ -27,10 +26,8 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{runner.os}}-pip-
-            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -54,11 +51,8 @@ jobs:
       PG_DATABASE: awa
       PG_USER: ${{env.POSTGRES_USER}}
       PG_PASSWORD: ${{env.POSTGRES_PASSWORD}}
-      PG_USER: postgres
-      PG_PASSWORD: pass # pragma: allowlist secret
       PG_HOST: localhost
       DATA_DIR: ${{runner.temp}}/awa-data
-      DATA_DIR: $RUNNER_TEMP/awa-data
     services:
       postgres:
         image: postgres:15
@@ -81,10 +75,8 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{runner.os}}-pip-
-            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -110,11 +102,19 @@ jobs:
         run: echo "DATABASE_URL=postgresql+psycopg://postgres:pass@localhost:5432/awa" >> $GITHUB_ENV # pragma: allowlist secret
       - name: Run migrations
         run: alembic upgrade head
-@@ -120,60 +120,60 @@ jobs:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: pass # pragma: allowlist secret
-      PG_DATABASE: awa
-      POSTGRES_DB: awa
+      - run: ruff check .
+      - run: black --check .
+      - run: mypy services || true
+      - name: Run tests
+        run: pytest -q
+      - name: Dump compose logs (always)
+        if: always()
+        run: |
+          docker compose ps
+          docker compose logs --no-color --tail=300
+
+  importer-test:
+    needs: postgres
     services:
       postgres:
         image: postgres:15
@@ -137,10 +137,8 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{runner.os}}-pip-${{hashFiles('**/requirements*.txt')}}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{runner.os}}-pip-
-            ${{ runner.os }}-pip-
       - name: Install all Python requirements
         run: |
           python -m pip install --upgrade pip
@@ -162,9 +160,6 @@ jobs:
           PG_USER: ${{env.POSTGRES_USER}}
           PG_PASSWORD: ${{env.POSTGRES_PASSWORD}}
           PG_DATABASE: ${{env.PG_DATABASE}}
-          PG_USER: postgres
-          PG_PASSWORD: pass # pragma: allowlist secret
-          PG_DATABASE: awa
           PG_HOST: localhost
       - run: |
           docker run --network host \


### PR DESCRIPTION
## Summary
- revert `.github/workflows/ci.yml` to valid YAML
- ensure CI workflow parses by removing stray diff markers
- remove runner and env from importer-test job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716aa435e08333aae3f33f4a445951