### PR TITLE
Add React unit tests and cookie-based auth

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,8 +6,8 @@ import { AuthProvider, useAuth } from './context/AuthContext'
 import type { ReactElement } from 'react'
 
 function PrivateRoute({ children }: { children: ReactElement }) {
-  const { token } = useAuth()
-  return token ? children : <Navigate to="/login" replace />
+  const { loggedIn } = useAuth()
+  return loggedIn ? children : <Navigate to="/login" replace />
 }
 
 export default function App() {

--- a/web/src/__tests__/Dashboard.test.tsx
+++ b/web/src/__tests__/Dashboard.test.tsx
@@ -1,0 +1,45 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+expect.extend(matchers)
+import Dashboard from '../pages/Dashboard'
+import { AuthProvider } from '../context/AuthContext'
+import { BrowserRouter } from 'react-router-dom'
+import axios from 'axios'
+
+const kpiData = [
+  { name: 'Total SKU', value: 10 },
+  { name: 'Avg ROI %', value: 12 },
+  { name: 'Approved €', value: 1000 },
+  { name: 'Potential Profit €', value: 2000 },
+]
+const vendorData = [{ vendor: 'ACME', roi: 15 }]
+const trendData = [{ date: '2024-01-01', roi: 10 }]
+
+describe('Dashboard page', () => {
+  it('loads stats and renders charts', async () => {
+    const get = vi.fn()
+    get
+      .mockResolvedValueOnce({ data: kpiData })
+      .mockResolvedValueOnce({ data: vendorData })
+      .mockResolvedValueOnce({ data: trendData })
+    vi.spyOn(axios, 'create').mockReturnValue({
+      get,
+      interceptors: { response: { use: vi.fn() } },
+    } as any)
+
+    const { container } = render(
+      <AuthProvider>
+        <BrowserRouter>
+          <Dashboard />
+        </BrowserRouter>
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(3))
+    expect(screen.getByText('Total SKU')).toBeInTheDocument()
+    expect(container.querySelectorAll('.recharts-wrapper').length).toBe(2)
+  })
+})

--- a/web/src/__tests__/RoiReview.test.tsx
+++ b/web/src/__tests__/RoiReview.test.tsx
@@ -1,0 +1,38 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+expect.extend(matchers)
+import RoiReview from '../pages/RoiReview'
+import { AuthProvider } from '../context/AuthContext'
+import { BrowserRouter } from 'react-router-dom'
+import axios from 'axios'
+
+const rows = [
+  { asin: 'A1', title: 'Item 1', vendor_id: 1, cost: 1, freight: 1, fees: 1, roi_pct: 10 },
+]
+
+describe('ROI Review page', () => {
+  it('renders table rows from API', async () => {
+    const get = vi.fn().mockResolvedValue({ data: rows })
+    const post = vi.fn().mockResolvedValue({})
+    vi.spyOn(axios, 'create').mockReturnValue({
+      get,
+      post,
+      interceptors: { response: { use: vi.fn() } },
+    } as any)
+
+    render(
+      <AuthProvider>
+        <BrowserRouter>
+          <RoiReview />
+        </BrowserRouter>
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(get).toHaveBeenCalled())
+    expect(screen.getByText('Item 1')).toBeInTheDocument()
+    expect(screen.getByText('Approve Selected')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- implement cookie based auth context
- gate routes on loggedIn state
- add vitest unit tests for Dashboard and ROI Review pages

## Testing
- `npm test --silent`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740c9eb9648333b5b6a10cda768ca8