### PR TITLE
Add LLM provider switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=pass
+POSTGRES_PASSWORD=pass # pragma: allowlist secret
 POSTGRES_DB=awa
 POSTGRES_HOST=postgres
 PG_USER=${POSTGRES_USER}
@@ -8,3 +8,7 @@ PG_DATABASE=${POSTGRES_DB}
 PG_HOST=${POSTGRES_HOST}
 HELIUM10_KEY=
 FREIGHT_API_URL=
+LLM_PROVIDER=local
+LLM_URL=http://llm:8000/llm
+OPENAI_MODEL=gpt-4o-mini
+# OPENAI_API_KEY=sk-... # pragma: allowlist secret

--- a/.env.postgres
+++ b/.env.postgres
@@ -1,5 +1,5 @@
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=pass
+POSTGRES_PASSWORD=pass # pragma: allowlist secret
 POSTGRES_DB=awa
 POSTGRES_HOST=postgres
 PG_USER=${POSTGRES_USER}
@@ -8,3 +8,7 @@ PG_DATABASE=${POSTGRES_DB}
 PG_HOST=${POSTGRES_HOST}
 HELIUM10_KEY=
 FREIGHT_API_URL=
+LLM_PROVIDER=local
+LLM_URL=http://llm:8000/llm
+OPENAI_MODEL=gpt-4o-mini
+# OPENAI_API_KEY=sk-... # pragma: allowlist secret

--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ Browse high-margin SKUs with basic auth:
 ```bash
 curl -u admin:pass "http://localhost:8000/roi-review?roi_min=15"
 ```
+
+## LLM provider
+
+The emailer and future services call a configurable language model.
+Set `LLM_PROVIDER` to `local` (default) or `openai`. When using
+`openai`, provide `OPENAI_API_KEY` and optionally `OPENAI_MODEL`.

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,5 +1,6 @@
 from .base import Base
 from .models_vendor import Vendor, VendorPrice
 from .keepa import list_active_asins
+from . import llm
 
-__all__ = ["Base", "Vendor", "VendorPrice", "list_active_asins"]
+__all__ = ["Base", "Vendor", "VendorPrice", "list_active_asins", "llm"]

--- a/services/common/llm.py
+++ b/services/common/llm.py
@@ -1,0 +1,43 @@
+import os
+import httpx
+import importlib
+from typing import Any
+
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "local").lower()
+LOCAL_URL = os.getenv("LLM_URL", "http://llm:8000/llm")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+
+
+async def _local_llm(prompt: str, temp: float, max_toks: int) -> str:
+    async with httpx.AsyncClient(timeout=60) as cli:
+        r = await cli.post(
+            LOCAL_URL,
+            json={"prompt": prompt, "temperature": temp, "max_tokens": max_toks},
+        )
+        r.raise_for_status()
+        return r.json()["completion"]
+
+
+async def _openai_llm(prompt: str, temp: float, max_toks: int) -> str:
+    openai: Any = importlib.import_module("openai")
+    openai.api_key = OPENAI_API_KEY
+    rsp = await openai.ChatCompletion.acreate(
+        model=OPENAI_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=temp,
+        max_tokens=max_toks,
+    )
+    return rsp.choices[0].message.content.strip()
+
+
+async def generate(
+    prompt: str,
+    temperature: float = 0.7,
+    max_tokens: int = 256,
+    provider: str | None = None,
+) -> str:
+    prov = (provider or LLM_PROVIDER).lower()
+    if prov == "openai":
+        return await _openai_llm(prompt, temperature, max_tokens)
+    return await _local_llm(prompt, temperature, max_tokens)

--- a/services/emailer/generate_body.py
+++ b/services/emailer/generate_body.py
@@ -1,32 +1,5 @@
-import os
-import httpx
-
-LLM_URL = os.getenv("LLM_URL", "http://llm:8000/llm")
+from services.common.llm import generate
 
 
-async def local_llm(prompt: str, temp: float = 0.7, tokens: int = 256) -> str:
-    async with httpx.AsyncClient(timeout=60) as client:
-        r = await client.post(
-            LLM_URL, json={"prompt": prompt, "temperature": temp, "max_tokens": tokens}
-        )
-        r.raise_for_status()
-        return r.json()["completion"]
-
-
-async def generate_body(prompt: str, *, temperature: float = 0.7, max_tokens: int = 256) -> str:
-    key = os.getenv("OPENAI_API_KEY")
-    if key:
-        try:
-            from openai import AsyncOpenAI
-        except Exception:
-            key = None
-    if key:
-        client = AsyncOpenAI(api_key=key)
-        resp = await client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
-        return resp.choices[0].message.content
-    return await local_llm(prompt, temp=temperature, tokens=max_tokens)
+async def draft_email(prompt: str) -> str:
+    return await generate(prompt)

--- a/services/emailer/tests/test_generate_body.py
+++ b/services/emailer/tests/test_generate_body.py
@@ -2,44 +2,11 @@ import pytest
 from services.emailer import generate_body as gb
 
 
-class DummyResp:
-    status_code = 200
-
-    def __init__(self, payload):
-        self._payload = payload
-
-    def raise_for_status(self):
-        pass
-
-    def json(self):
-        return self._payload
-
-
-class DummyClient:
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def post(self, url, json):
-        return DummyResp({"completion": "ok"})
-
-
 @pytest.mark.asyncio
-async def test_local_llm(monkeypatch):
-    monkeypatch.setattr(gb.httpx, "AsyncClient", lambda timeout=60: DummyClient())
-    out = await gb.local_llm("hi")
-    assert out == "ok"
+async def test_draft_email(monkeypatch):
+    async def fake_generate(prompt: str):
+        return "EMAIL"
 
-
-@pytest.mark.asyncio
-async def test_generate_body_local(monkeypatch):
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-    async def fake_local(prompt: str, temp: float = 0.7, tokens: int = 256) -> str:
-        return "local"
-
-    monkeypatch.setattr(gb, "local_llm", fake_local)
-    result = await gb.generate_body("prompt")
-    assert result == "local"
+    monkeypatch.setattr(gb, "generate", fake_generate)
+    out = await gb.draft_email("hello")
+    assert out == "EMAIL"

--- a/tests/test_llm_switch.py
+++ b/tests/test_llm_switch.py
@@ -1,0 +1,22 @@
+import pytest
+from services.common import llm
+
+
+@pytest.mark.asyncio
+async def test_switch_to_local(monkeypatch):
+    async def fake_local(*a, **k):
+        return "LOCAL"
+
+    monkeypatch.setattr(llm, "_local_llm", fake_local)
+    out = await llm.generate("hi", provider="local")
+    assert out == "LOCAL"
+
+
+@pytest.mark.asyncio
+async def test_switch_to_openai(monkeypatch):
+    async def fake_openai(*a, **k):
+        return "GPT4o"
+
+    monkeypatch.setattr(llm, "_openai_llm", fake_openai)
+    out = await llm.generate("hi", provider="openai")
+    assert out == "GPT4o"


### PR DESCRIPTION
## Summary
- unify LLM access behind `services.common.llm.generate`
- add provider switch for local Llama vs OpenAI
- update emailer to use the helper
- document new environment variables
- test LLM provider switching

## Testing
- `pre-commit run --files .env.example .env.postgres README.md services/common/__init__.py services/common/llm.py services/emailer/generate_body.py services/emailer/tests/test_generate_body.py tests/test_llm_switch.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68741bf74164833398a4136a4f084a18