### PR TITLE
feat(web): React dashboard with SWR hooks and CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'web/package-lock.json'
       - run: npm ci
         working-directory: web
-      - run: npm run test --if-present
+      - run: npm test -- --run
         working-directory: web
-      - run: npm run build --if-present
+      - run: npm run build
         working-directory: web
       - run: ruff check .
       - run: black --check .
@@ -104,11 +106,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'web/package-lock.json'
       - run: npm ci
         working-directory: web
-      - run: npm run test --if-present
+      - run: npm test -- --run
         working-directory: web
-      - run: npm run build --if-present
+      - run: npm run build
         working-directory: web
       - name: Prepare DB
         run: |

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,3 +14,7 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
+  web:
+    build: services/web
+    ports: ["3000:80"]
+    depends_on: [api]

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import Depends, FastAPI  # type: ignore[attr-defined]
 
 from .routes.roi import router as roi_router
+from .routes.stats import router as stats_router
 
 from .db import get_session
 from services.common.db_url import build_url
@@ -21,6 +22,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(roi_router)
+app.include_router(stats_router)
 
 
 async def _wait_for_db() -> None:

--- a/services/api/routes/stats.py
+++ b/services/api/routes/stats.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/stats/kpi")
+def kpi():
+    """Return KPI metrics (mock)."""
+    # TODO: replace with SQL queries
+    return [
+        {"name": "Total SKU", "value": 10},
+        {"name": "Avg ROI %", "value": 12},
+        {"name": "Approved €", "value": 1000},
+        {"name": "Potential Profit €", "value": 2000},
+    ]
+
+
+@router.get("/stats/roi_by_vendor")
+def roi_by_vendor():
+    """Return ROI percent by vendor."""
+    # TODO: replace with SQL queries
+    return [{"vendor": "ACME", "roi": 15}]
+
+
+@router.get("/stats/roi_trend")
+def roi_trend():
+    """Return 30-day ROI trend."""
+    # TODO: replace with SQL queries
+    return [{"date": "2024-01-01", "roi": 10}]

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY web/ .
+RUN npm ci && npm run build
+FROM nginx:1.25-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.3",
         "recharts": "^3.1.0",
+        "swr": "^2.3.4",
         "tailwindcss": "^4.1.11"
       },
       "devDependencies": {
@@ -3427,9 +3428,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6109,6 +6108,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
     "recharts": "^3.1.0",
+    "swr": "^2.3.4",
     "tailwindcss": "^4.1.11"
   },
   "devDependencies": {

--- a/web/src/__tests__/Dashboard.test.tsx
+++ b/web/src/__tests__/Dashboard.test.tsx
@@ -7,7 +7,7 @@ expect.extend(matchers)
 import Dashboard from '../pages/Dashboard'
 import { AuthProvider } from '../context/AuthContext'
 import { BrowserRouter } from 'react-router-dom'
-import axios from 'axios'
+import { api } from '../lib/api'
 
 const kpiData = [
   { name: 'Total SKU', value: 10 },
@@ -20,15 +20,11 @@ const trendData = [{ date: '2024-01-01', roi: 10 }]
 
 describe('Dashboard page', () => {
   it('loads stats and renders charts', async () => {
-    const get = vi.fn()
-    get
-      .mockResolvedValueOnce({ data: kpiData })
-      .mockResolvedValueOnce({ data: vendorData })
-      .mockResolvedValueOnce({ data: trendData })
-    vi.spyOn(axios, 'create').mockReturnValue({
-      get,
-      interceptors: { response: { use: vi.fn() } },
-    } as any)
+    const get = vi
+      .spyOn(api, 'get')
+      .mockResolvedValueOnce({ data: kpiData } as any)
+      .mockResolvedValueOnce({ data: vendorData } as any)
+      .mockResolvedValueOnce({ data: trendData } as any)
 
     const { container } = render(
       <AuthProvider>

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
-import axios, { type AxiosInstance } from 'axios'
+import type { AxiosInstance } from 'axios'
 import React, { createContext, useContext, useState } from 'react'
+import { api } from '../lib/api'
 
 interface AuthCtx {
   loggedIn: boolean
@@ -13,11 +14,6 @@ const AuthContext = createContext<AuthCtx>(null as unknown as AuthCtx)
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loggedIn, setLoggedIn] = useState(false)
 
-  const api = axios.create({
-    baseURL: import.meta.env.VITE_API_URL || '',
-    withCredentials: true,
-  })
-
   api.interceptors.response.use(
     (r) => r,
     (error) => {
@@ -25,6 +21,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return Promise.reject(error)
     },
   )
+  api.interceptors.request.use((config) => {
+    const m = document.cookie.match(/access_token=([^;]+)/)
+    if (m) config.headers.Authorization = `Bearer ${m[1]}`
+    return config
+  })
 
   const login = async (username: string, password: string) => {
     await api.post('/auth/token', { username, password })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,18 @@
+import axios from 'axios'
+import useSWR from 'swr'
+
+export const api = axios.create({ baseURL: '/api', withCredentials: true })
+
+export const useKpi = () =>
+  useSWR('/stats/kpi', () => api.get('/stats/kpi').then((r) => r.data))
+
+export const useRoiByVend = () =>
+  useSWR('/stats/roi_by_vendor', () =>
+    api.get('/stats/roi_by_vendor').then((r) => r.data),
+  )
+
+export const useRoiTrend = () =>
+  useSWR('/stats/roi_trend', () => api.get('/stats/roi_trend').then((r) => r.data))
+
+export const useRoiTable = (params: string) =>
+  useSWR(`/roi-review?${params}`, () => api.get(`/roi-review?${params}`).then((r) => r.data))

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,37 +1,19 @@
-import { useEffect, useState } from 'react'
-import { useAuth } from '../context/AuthContext'
 import { BarChart, Bar, XAxis, YAxis, LineChart, Line } from 'recharts'
+import { useKpi, useRoiByVend, useRoiTrend } from '../lib/api'
 
-interface KPI {
+interface Kpi {
   name: string
   value: number
 }
-interface VendorROI { vendor: string; roi: number }
-interface TrendPoint { date: string; roi: number }
 
 export default function Dashboard() {
-  const { api } = useAuth()
-  const [kpis, setKpis] = useState<KPI[]>([])
-  const [vendors, setVendors] = useState<VendorROI[]>([])
-  const [trend, setTrend] = useState<TrendPoint[]>([])
-  useEffect(() => {
-    api
-      .get<KPI[]>('/stats/kpi')
-      .then((r) => setKpis(r.data))
-      .catch(() => setKpis([]))
-    api
-      .get<VendorROI[]>('/stats/roi_by_vendor')
-      .then((r) => setVendors(r.data))
-      .catch(() => setVendors([]))
-    api
-      .get<TrendPoint[]>('/stats/roi_trend')
-      .then((r) => setTrend(r.data))
-      .catch(() => setTrend([]))
-  }, [api])
+  const { data: kpis = [] } = useKpi()
+  const { data: vendors = [] } = useRoiByVend()
+  const { data: trend = [] } = useRoiTrend()
   return (
     <div className="p-4 space-y-4">
       <div className="grid grid-cols-3 gap-4">
-        {kpis.map((k) => (
+        {kpis.map((k: Kpi) => (
           <div key={k.name} className="p-4 bg-white rounded shadow">
             <div className="text-sm text-gray-500">{k.name}</div>
             <div className="text-2xl font-bold">{k.value}</div>

--- a/web/src/pages/RoiReview.tsx
+++ b/web/src/pages/RoiReview.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
 import type { ColumnDef } from '@tanstack/react-table'
-import { useAuth } from '../context/AuthContext'
+import { api, useRoiTable } from '../lib/api'
 
 interface Row {
   asin: string
@@ -18,27 +18,16 @@ interface Row {
 }
 
 export default function RoiReview() {
-  const { api } = useAuth()
-  const [data, setData] = useState<Row[]>([])
   const [roiMin, setRoiMin] = useState('')
   const [vendor, setVendor] = useState('')
   const [category, setCategory] = useState('')
   const [selected, setSelected] = useState<string[]>([])
-
-  const load = () => {
-    api
-      .get<Row[]>('/roi-review', {
-        params: {
-          roi_min: roiMin || undefined,
-          vendor: vendor || undefined,
-          category: category || undefined,
-        },
-      })
-      .then((r) => setData(r.data))
-      .catch(() => setData([]))
-  }
-
-  useEffect(load, [roiMin, vendor, category, api])
+  const params = new URLSearchParams({
+    roi_min: roiMin,
+    vendor,
+    category,
+  })
+  const { data = [], mutate } = useRoiTable(params.toString())
 
   const columns: ColumnDef<Row>[] = [
     {
@@ -92,7 +81,7 @@ export default function RoiReview() {
         />
         <button
           className="bg-blue-600 text-white px-2 rounded"
-          onClick={load}
+          onClick={() => mutate()}
           type="button"
         >
           Filter
@@ -102,7 +91,7 @@ export default function RoiReview() {
           onClick={async () => {
             await api.post('/roi-review/approve', { asins: selected })
             setSelected([])
-            load()
+            mutate()
           }}
           type="button"
         >


### PR DESCRIPTION
## Summary
- add web Dockerfile and compose override
- expose new `/stats` endpoints with mock data
- implement SWR API hooks and auth interceptor
- refactor dashboard and ROI review pages
- update Vitest tests
- cache npm deps in CI

## Testing
- `pre-commit run --files docker-compose.override.yml services/web/Dockerfile services/api/routes/stats.py services/api/main.py web/src/lib/api.ts web/src/context/AuthContext.tsx web/src/pages/Dashboard.tsx web/src/pages/RoiReview.tsx web/src/__tests__/Dashboard.test.tsx web/src/__tests__/RoiReview.test.tsx`
- `pytest -q`
- `npm test -- --run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687421d0e6888333ba0dd60f4f90490a