### PR TITLE
Fix helium fees table recreation

### DIFF
--- a/services/api/migrations/versions/0009_fees_raw_fix.py
+++ b/services/api/migrations/versions/0009_fees_raw_fix.py
@@ -1,0 +1,17 @@
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "0009_fees_raw_fix"
+down_revision = "0006_fix_roi_views"
+branch_labels = depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS fees_raw CASCADE")
+    op.execute(
+        "CREATE TABLE fees_raw("
+        "sku text primary key, fee numeric, captured_at timestamptz default now())"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS fees_raw")

--- a/services/etl/helium_fees_ingestor.py
+++ b/services/etl/helium_fees_ingestor.py
@@ -29,7 +29,7 @@ def main() -> int:
         results = [(r["sku"], r["totalFbaFee"]) for r in data]
     conn = connect(dsn)
     cur = conn.cursor()
-    cur.execute("DROP TABLE IF EXISTS fees_raw")
+    cur.execute("DROP TABLE IF EXISTS fees_raw CASCADE")
     cur.execute(
         "CREATE TABLE fees_raw("
         "sku text primary key, fee numeric, captured_at timestamptz default now())"

--- a/tests/test_helium_fees_ingestor.py
+++ b/tests/test_helium_fees_ingestor.py
@@ -33,15 +33,28 @@ def fake_connect(dsn):
     return FakeConn()
 
 
-sys.modules["pg_utils"] = types.SimpleNamespace(connect=fake_connect)
+sys.modules["pg_utils"] = types.SimpleNamespace(connect=fake_connect)  # type: ignore[assignment]
 helium_fees_ingestor.connect = fake_connect
 
 
 def test_offline(monkeypatch):
     os.environ["ENABLE_LIVE"] = "0"
     os.environ["HELIUM_API_KEY"] = "k"
-    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "").replace(
-        "postgresql+psycopg://", "postgresql://"
-    ) or "postgresql://postgres:pass@localhost:5432/awa"
+    os.environ["DATABASE_URL"] = (
+        os.getenv("DATABASE_URL", "").replace("postgresql+psycopg://", "postgresql://")
+        or "postgresql://postgres:pass@localhost:5432/awa"  # pragma: allowlist secret
+    )
     res = helium_fees_ingestor.main()
     assert res == 0
+
+
+def test_run_twice(monkeypatch):
+    os.environ["ENABLE_LIVE"] = "0"
+    os.environ["HELIUM_API_KEY"] = "k"
+    os.environ["DATABASE_URL"] = (
+        os.getenv("DATABASE_URL", "").replace("postgresql+psycopg://", "postgresql://")
+        or "postgresql://postgres:pass@localhost:5432/awa"  # pragma: allowlist secret
+    )
+
+    helium_fees_ingestor.main()
+    helium_fees_ingestor.main()


### PR DESCRIPTION
## Summary
- rebuild fees_raw table with CASCADE in the ingestor
- add alembic migration to drop and recreate fees_raw
- test that helium_fees_ingestor.main() can run twice without error

## Testing
- `pre-commit run --files services/etl/helium_fees_ingestor.py services/api/migrations/versions/0009_fees_raw_fix.py tests/test_helium_fees_ingestor.py`
- `pytest tests/test_helium_fees_ingestor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687542db787483339b44d47144cadc7c