### PR TITLE
Update fees_raw schema + DSN builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,13 +117,17 @@ jobs:
         working-directory: web
       - run: npm test -- --run
         working-directory: web
-      - run: npm run build
-        working-directory: web
-      - name: Prepare DB
-        run: |
-          if ! psql -h localhost -p 5432 -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='awa'" | grep -q 1; then
-            createdb -h localhost -p 5432 -U postgres awa
-          fi
+        - run: npm run build
+          working-directory: web
+        - name: Export DSN
+          run: echo "DATABASE_URL=postgresql://postgres:pass@localhost:5432/awa" >> $GITHUB_ENV
+        - name: Wait for DB
+          run: for i in {1..30}; do pg_isready -h localhost -p 5432 -U postgres && break || sleep 2; done
+        - name: Prepare DB
+          run: |
+            if ! psql -h localhost -p 5432 -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='awa'" | grep -q 1; then
+              createdb -h localhost -p 5432 -U postgres awa
+            fi
         env:
           PGPASSWORD: pass # pragma: allowlist secret
       - name: Run migrations

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from logging.config import fileConfig
 from sqlalchemy import create_engine
 from alembic import context  # type: ignore
-import os
+from services.common.dsn import build_dsn
 
 
 config = context.config
@@ -12,10 +12,7 @@ if config.config_file_name is not None:
 target_metadata = None
 
 
-url = os.getenv(
-    "DATABASE_URL",
-    "postgresql+psycopg://postgres:pass@postgres:5432/postgres",
-)
+url = build_dsn()
 connectable = create_engine(url, pool_pre_ping=True)
 
 

--- a/services/api/migrations/versions/0010_rename_fees_raw.py
+++ b/services/api/migrations/versions/0010_rename_fees_raw.py
@@ -1,0 +1,20 @@
+from alembic import op
+
+revision, down_revision = "0009_fees_raw_fix", "0009_fees_raw_fix"
+
+
+def upgrade():
+    op.execute("DROP TABLE IF EXISTS fees_raw CASCADE")
+    op.execute(
+        """
+        CREATE TABLE fees_raw(
+          asin text primary key,
+          fee numeric,
+          captured_at timestamptz default now()
+        )
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP TABLE IF EXISTS fees_raw")

--- a/services/api/routes/repository.py
+++ b/services/api/routes/repository.py
@@ -21,8 +21,8 @@ ROI_QUERY = text(
     JOIN freight_rates fr ON fr.lane = 'EU→IT' AND fr.mode = 'sea'
     JOIN fees_raw      f  USING (asin)
     WHERE v_roi_full.roi_pct >= :roi_min
-      AND (:vendor IS NULL OR vp.vendor_id = :vendor)
-      AND (:category IS NULL OR p.category = :category)
+      AND (:vendor::text IS NULL OR vp.vendor_id = :vendor::text)
+      AND (:category::text IS NULL OR p.category = :category::text)
     LIMIT 200;
     """
 ).bindparams(

--- a/services/api/routes/roi.py
+++ b/services/api/routes/roi.py
@@ -50,8 +50,8 @@ ROI_SQL = text(
         JOIN fees_raw f  ON f.asin = p.asin
         WHERE vf.roi_pct >= :roi_min
           AND COALESCE(p.status, 'pending') = 'pending'
-          AND vp.vendor_id = COALESCE(CAST(:vendor AS INTEGER), vp.vendor_id)
-          AND (CAST(:category AS TEXT) IS NULL OR p.category = CAST(:category AS TEXT))
+          AND (:vendor::text IS NULL OR vp.vendor_id = :vendor::text)
+          AND (:category::text IS NULL OR p.category = :category::text)
         LIMIT 200
         """
 ).bindparams(

--- a/services/common/dsn.py
+++ b/services/common/dsn.py
@@ -1,0 +1,13 @@
+import os
+import urllib.parse as _u
+
+
+def build_dsn() -> str:
+    if url := os.getenv("DATABASE_URL"):
+        return url
+    host = os.getenv("PG_HOST", "localhost")
+    port = os.getenv("PG_PORT", "5432")
+    user = _u.quote_plus(os.getenv("PG_USER", "postgres"))
+    pwd = _u.quote_plus(os.getenv("PG_PASSWORD", "pass"))
+    db = os.getenv("PG_DATABASE", "awa")
+    return f"postgresql://{user}:{pwd}@{host}:{port}/{db}"

--- a/services/etl/helium_fees_ingestor.py
+++ b/services/etl/helium_fees_ingestor.py
@@ -26,19 +26,19 @@ def main() -> int:
     else:
         with open("tests/fixtures/helium_fees_sample.json") as f:
             data = json.load(f)
-        results = [(r["sku"], r["totalFbaFee"]) for r in data]
+        results = [(r["asin"], r["totalFbaFee"]) for r in data]
     conn = connect(dsn)
     cur = conn.cursor()
     cur.execute("DROP TABLE IF EXISTS fees_raw CASCADE")
     cur.execute(
         "CREATE TABLE fees_raw("
-        "sku text primary key, fee numeric, captured_at timestamptz default now())"
+        "asin text primary key, fee numeric, captured_at timestamptz default now())"
     )
-    for sku, fee in results:
+    for asin, fee in results:
         cur.execute(
-            "INSERT INTO fees_raw(sku, fee) VALUES (%s, %s) "
-            "ON CONFLICT (sku) DO UPDATE SET fee = EXCLUDED.fee",
-            (sku, fee),
+            "INSERT INTO fees_raw(asin, fee) VALUES (%s,%s) "
+            "ON CONFLICT (asin) DO UPDATE SET fee = EXCLUDED.fee",
+            (asin, fee),
         )
     conn.commit()
     cur.close()

--- a/services/etl/sp_fees_ingestor.py
+++ b/services/etl/sp_fees_ingestor.py
@@ -24,16 +24,16 @@ def main() -> int:
             region=region,
         )
         results = []
-        for sku in skus:
-            r = api.get_my_fees_estimate_for_sku(sku)
+        for asin in skus:
+            r = api.get_my_fees_estimate_for_sku(asin)
             amt = r["payload"]["FeesEstimateResult"]["FeesEstimate"]["TotalFeesEstimate"]["Amount"]
-            results.append((sku, amt))
+            results.append((asin, amt))
     else:
         with open("tests/fixtures/spapi_fees_sample.json") as f:
             data = json.load(f)
         results = [
             (
-                r["sku"],
+                r["asin"],
                 r["payload"]["FeesEstimateResult"]["FeesEstimate"]["TotalFeesEstimate"]["Amount"],
             )
             for r in data
@@ -42,13 +42,13 @@ def main() -> int:
     cur = conn.cursor()
     cur.execute(
         "CREATE TABLE IF NOT EXISTS fees_raw("
-        "sku text primary key, fee numeric, captured_at timestamptz default now())"
+        "asin text primary key, fee numeric, captured_at timestamptz default now())"
     )
-    for sku, fee in results:
+    for asin, fee in results:
         cur.execute(
-            "INSERT INTO fees_raw(sku, fee) VALUES (%s, %s) "
-            "ON CONFLICT (sku) DO UPDATE SET fee = EXCLUDED.fee",
-            (sku, fee),
+            "INSERT INTO fees_raw(asin, fee) VALUES (%s, %s) "
+            "ON CONFLICT (asin) DO UPDATE SET fee = EXCLUDED.fee",
+            (asin, fee),
         )
     conn.commit()
     cur.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from asyncpg import create_pool
 
 from tests.utils import run_migrations
+from services.common.dsn import build_dsn
 
 os.environ.setdefault("ENABLE_LIVE", "0")
 os.environ.setdefault("TESTING", "1")
@@ -23,14 +24,12 @@ PG_DATABASE = os.getenv("PG_DATABASE", "awa")
 
 @pytest.fixture(autouse=True)
 def _set_db_url():
-    url = f"postgresql+psycopg://{PG_USER}:{PG_PASSWORD}@{PG_HOST}:{PG_PORT}/{PG_DATABASE}"
-    os.environ["DATABASE_URL"] = url
+    os.environ["DATABASE_URL"] = build_dsn()
 
 
 @pytest.fixture
 async def pg_pool(_set_db_url):
-    dsn = os.environ["DATABASE_URL"].replace("postgresql+psycopg://", "postgresql://")
-    pool = await create_pool(dsn=dsn)
+    pool = await create_pool(dsn=build_dsn())
     await run_migrations()
     yield pool
     await pool.close()

--- a/tests/fixtures/helium_fees_sample.json
+++ b/tests/fixtures/helium_fees_sample.json
@@ -1,4 +1,4 @@
 [
-  {"sku": "DUMMY1", "totalFbaFee": 1.11},
-  {"sku": "DUMMY2", "totalFbaFee": 2.22}
+  {"asin": "DUMMY1", "totalFbaFee": 1.11},
+  {"asin": "DUMMY2", "totalFbaFee": 2.22}
 ]

--- a/tests/fixtures/spapi_fees_sample.json
+++ b/tests/fixtures/spapi_fees_sample.json
@@ -1,6 +1,6 @@
 [
   {
-    "sku": "DUMMY1",
+    "asin": "DUMMY1",
     "payload": {
       "FeesEstimateResult": {
         "FeesEstimate": {
@@ -12,7 +12,7 @@
     }
   },
   {
-    "sku": "DUMMY2",
+    "asin": "DUMMY2",
     "payload": {
       "FeesEstimateResult": {
         "FeesEstimate": {

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1,7 +1,7 @@
 from alembic.config import Config  # type: ignore[attr-defined]
 from alembic import command  # type: ignore[attr-defined]
 from sqlalchemy import create_engine, text
-import os
+from services.common.dsn import build_dsn
 
 
 def test_run_migrations(tmp_path, monkeypatch, pg_pool):
@@ -13,7 +13,7 @@ def test_run_migrations(tmp_path, monkeypatch, pg_pool):
     cfg = Config("alembic.ini")
     command.upgrade(cfg, "head")
     command.upgrade(cfg, "head")
-    engine = create_engine(os.environ["DATABASE_URL"])
+    engine = create_engine(build_dsn())
     with engine.begin() as conn:
         conn.execute(text("INSERT INTO products(asin) VALUES ('A1')"))
         conn.execute(

--- a/tests/test_fees_h10.py
+++ b/tests/test_fees_h10.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+from services.common.dsn import build_dsn
 
 import pytest
 from httpx import Response
@@ -28,7 +29,7 @@ async def test_fetch_fees():
 @pytest.mark.asyncio
 async def test_repository_upsert(tmp_path, monkeypatch, pg_pool):
     importlib.reload(repository)
-    engine = create_engine(os.environ["DATABASE_URL"])
+    engine = create_engine(build_dsn())
     with engine.begin() as conn:
         conn.exec_driver_sql(
             """
@@ -71,7 +72,7 @@ async def test_repository_upsert(tmp_path, monkeypatch, pg_pool):
 def test_refresh_fees(tmp_path, monkeypatch, pg_pool):
     importlib.reload(repository)
     importlib.reload(worker)
-    engine = create_engine(os.environ["DATABASE_URL"])
+    engine = create_engine(build_dsn())
     with engine.begin() as conn:
         conn.exec_driver_sql(
             """

--- a/tests/test_helium_fees.py
+++ b/tests/test_helium_fees.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import sys
 import types
+from services.common.dsn import build_dsn
 
 
 class FakeCursor:
@@ -31,7 +32,7 @@ class FakeConn:
 
 def test_offline(monkeypatch):
     os.environ.pop("ENABLE_LIVE", None)
-    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "d")
+    os.environ["DATABASE_URL"] = build_dsn()
     called = {"n": 0}
 
     def fake_get(url):

--- a/tests/test_helium_fees_ingestor.py
+++ b/tests/test_helium_fees_ingestor.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+from services.common.dsn import build_dsn
 from services.etl import helium_fees_ingestor
 
 
@@ -40,10 +41,7 @@ helium_fees_ingestor.connect = fake_connect
 def test_offline(monkeypatch):
     os.environ["ENABLE_LIVE"] = "0"
     os.environ["HELIUM_API_KEY"] = "k"
-    os.environ["DATABASE_URL"] = (
-        os.getenv("DATABASE_URL", "").replace("postgresql+psycopg://", "postgresql://")
-        or "postgresql://postgres:pass@localhost:5432/awa"  # pragma: allowlist secret
-    )
+    os.environ["DATABASE_URL"] = build_dsn()
     res = helium_fees_ingestor.main()
     assert res == 0
 
@@ -51,10 +49,7 @@ def test_offline(monkeypatch):
 def test_run_twice(monkeypatch):
     os.environ["ENABLE_LIVE"] = "0"
     os.environ["HELIUM_API_KEY"] = "k"
-    os.environ["DATABASE_URL"] = (
-        os.getenv("DATABASE_URL", "").replace("postgresql+psycopg://", "postgresql://")
-        or "postgresql://postgres:pass@localhost:5432/awa"  # pragma: allowlist secret
-    )
+    os.environ["DATABASE_URL"] = build_dsn()
 
     helium_fees_ingestor.main()
     helium_fees_ingestor.main()

--- a/tests/test_migration_0004.py
+++ b/tests/test_migration_0004.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine, text
 from alembic.config import Config  # type: ignore[attr-defined]
 from alembic import command  # type: ignore[attr-defined]
-import os
+from services.common.dsn import build_dsn
 
 
 def test_upgrade_storage_fee_column_exists(tmp_path, monkeypatch, pg_pool):
@@ -15,6 +15,6 @@ def test_upgrade_storage_fee_column_exists(tmp_path, monkeypatch, pg_pool):
     cfg = Config("alembic.ini")
     command.upgrade(cfg, "head")
     command.upgrade(cfg, "head")
-    engine = create_engine(os.environ["DATABASE_URL"])
+    engine = create_engine(build_dsn())
     with engine.connect() as conn:
         conn.execute(text("SELECT storage_fee FROM fees_raw LIMIT 1"))

--- a/tests/test_roi_review.py
+++ b/tests/test_roi_review.py
@@ -1,9 +1,9 @@
 from sqlalchemy import create_engine, text
-import os
+from services.common.dsn import build_dsn
 
 
 def _setup_db():
-    engine = create_engine(os.environ["DATABASE_URL"])
+    engine = create_engine(build_dsn())
     with engine.begin() as conn:
         # Ensure clean state for deterministic tests
         for tbl in [

--- a/tests/test_sp_fees.py
+++ b/tests/test_sp_fees.py
@@ -1,6 +1,7 @@
 import os
 import types
 import sys
+from services.common.dsn import build_dsn
 
 
 class FakeCursor:
@@ -38,7 +39,7 @@ class FakeSP:
 
 def test_main_offline(monkeypatch):
     os.environ.pop("ENABLE_LIVE", None)
-    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "d")
+    os.environ["DATABASE_URL"] = build_dsn()
     fake_api = FakeSP()
     monkeypatch.setitem(
         sys.modules,

--- a/tests/test_sp_fees_ingestor.py
+++ b/tests/test_sp_fees_ingestor.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+from services.common.dsn import build_dsn
 from services.etl import sp_fees_ingestor
 
 
@@ -44,6 +45,6 @@ def test_offline(monkeypatch, tmp_path):
     os.environ["SP_CLIENT_SECRET"] = "s"
     os.environ["SELLER_ID"] = "seller"
     os.environ["REGION"] = "EU"
-    os.environ["DATABASE_URL"] = os.getenv("DATABASE_URL", "dsn")
+    os.environ["DATABASE_URL"] = build_dsn()
     res = sp_fees_ingestor.main()
     assert res == 0


### PR DESCRIPTION
## Summary
- migrate `fees_raw` table to use `asin` instead of `sku`
- add `services/common/dsn.py` helper and use in tests
- cast ROI filter params to text to avoid AmbiguousParameter
- silence asyncio warnings via pytest.ini (already existed)
- tweak CI to export DSN and wait for postgres

## Testing
- `ruff check .`
- `black --check .`
- `python -m mypy services`
- `pytest -q` *(fails: OSError connecting to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_687562e586488333a77060a1f8928d73