### PR TITLE
Add universal DSN builder and export in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       PG_USER: postgres
       PG_PASSWORD: pass # pragma: allowlist secret
       PG_HOST: localhost
-      DATABASE_URL: postgresql+psycopg://postgres:pass@localhost:5432/awa
+      DATABASE_URL: postgresql+psycopg://postgres:pass@localhost:5432/awa # pragma: allowlist secret
       DATA_DIR: $RUNNER_TEMP/awa-data
     services:
       postgres:
@@ -121,7 +121,9 @@ jobs:
         working-directory: web
 
       - name: Export DSN
-        run: echo "DATABASE_URL=postgresql://postgres:pass@localhost:5432/awa" >> $GITHUB_ENV
+        run: |
+          echo "DATABASE_URL=postgresql+psycopg://$PG_USER:$PG_PASSWORD@$PG_HOST:5432/$PG_DATABASE" >> $GITHUB_ENV
+          echo "PG_ASYNC_DSN=postgresql://$PG_USER:$PG_PASSWORD@$PG_HOST:5432/$PG_DATABASE"       >> $GITHUB_ENV
 
       - name: Wait for DB
         run: for i in {1..30}; do pg_isready -h localhost -p 5432 -U postgres && break || sleep 2; done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,6 @@ jobs:
       PG_DATABASE: awa
     steps:
       - uses: actions/checkout@v4
-      - name: Wait for Postgres to accept connections
-        env:
-          PGPASSWORD: pass                     # pragma: allowlist secret
-        run: |
-          for i in {1..40}; do
-            pg_isready -h localhost -p 5432 -U postgres && exit 0
-            sleep 2
-          done
-          echo "Postgres service never became ready" && exit 1
       - name: System deps
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql postgresql-client
@@ -94,6 +85,15 @@ jobs:
           --health-retries=10
     steps:
       - uses: actions/checkout@v4
+      - name: Wait for Postgres to accept connections
+        env:
+          PGPASSWORD: pass                     # pragma: allowlist secret
+        run: |
+          for i in {1..40}; do
+            pg_isready -h localhost -p 5432 -U postgres && exit 0
+            sleep 2
+          done
+          echo "Postgres service never became ready" && exit 1
       - name: System deps
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql postgresql-client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
       PG_DATABASE: awa
     steps:
       - uses: actions/checkout@v4
+      - name: Wait for Postgres to accept connections
+        env:
+          PGPASSWORD: pass                     # pragma: allowlist secret
+        run: |
+          for i in {1..40}; do
+            pg_isready -h localhost -p 5432 -U postgres && exit 0
+            sleep 2
+          done
+          echo "Postgres service never became ready" && exit 1
       - name: System deps
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql postgresql-client
@@ -125,9 +134,6 @@ jobs:
           echo "DATABASE_URL=postgresql+psycopg://$PG_USER:$PG_PASSWORD@$PG_HOST:5432/$PG_DATABASE" >> $GITHUB_ENV
           echo "PG_ASYNC_DSN=postgresql://$PG_USER:$PG_PASSWORD@$PG_HOST:5432/$PG_DATABASE"       >> $GITHUB_ENV
 
-      - name: Wait for DB
-        run: for i in {1..30}; do pg_isready -h localhost -p 5432 -U postgres && break || sleep 2; done
-
       - name: Prepare DB
         env:
           PGPASSWORD: pass      # pragma: allowlist secret
@@ -135,9 +141,10 @@ jobs:
           if ! psql -h localhost -p 5432 -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='awa'" | grep -q 1; then
             createdb -h localhost -p 5432 -U postgres awa
           fi
+      - name: Export PGHOST
+        run: echo "PGHOST=localhost" >> $GITHUB_ENV
       - name: Run migrations
         run: alembic upgrade head
-      - run: echo 'PGHOST=localhost' >> $GITHUB_ENV
       - name: Run tests
         run: pytest -q
       - name: Dump Postgres logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
           done
           python -m pip install asyncpg
           python -m pip install pytest ruff black mypy pytest-postgresql==5.1.1
-      - run: docker build -t price_importer services/price_importer
+      - run: docker build -t price_importer -f services/price_importer/Dockerfile .
       - name: Build llm image
         if: ${{ runner.os == 'Linux' && (runner.name == 'self-hosted' || env.GPU == 'true') }}
         run: docker build -t llm_server services/llm_server

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ curl http://localhost:8000/health
 The stack uses Postgres for all services. Copy `.env.example` to `.env.postgres`
 and run docker compose to start the database and API containers.
 
+### Database config – env matrix
+
+`build_dsn(sync=True|False)` derives a DSN from `DATABASE_URL` or the `PG_*`
+variables.  CI exports both a synchronous URL and an async-friendly variant:
+
+```
+DATABASE_URL=postgresql+psycopg://postgres:pass@localhost:5432/awa  # pragma: allowlist secret
+PG_ASYNC_DSN=postgresql://postgres:pass@localhost:5432/awa  # pragma: allowlist secret
+```
+Services and tests read these values automatically.
+
 ### Continuous Integration
 
 The GitHub Actions test workflow uses a Postgres service container. It waits

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from logging.config import fileConfig
 from sqlalchemy import create_engine
 from alembic import context  # type: ignore
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 
 
 config = context.config
@@ -12,7 +12,7 @@ if config.config_file_name is not None:
 target_metadata = None
 
 
-url = build_sqlalchemy_url()
+url = build_dsn(sync=True)
 connectable = create_engine(url, pool_pre_ping=True)
 
 

--- a/services/api/db.py
+++ b/services/api/db.py
@@ -8,9 +8,9 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.pool import NullPool
 
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 
-DATABASE_URL = build_url(async_=True)
+DATABASE_URL = build_dsn(sync=False)
 
 pool_kwargs = {}
 if os.getenv("TESTING") == "1":

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -11,7 +11,7 @@ from .routes.roi import router as roi_router
 from .routes.stats import router as stats_router
 
 from .db import get_session
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 
 
 @asynccontextmanager
@@ -29,7 +29,7 @@ async def _wait_for_db() -> None:
     """Block application startup until the database becomes available."""
     from sqlalchemy import create_engine
 
-    url = build_url(async_=False)
+    url = build_dsn(sync=True)
     delay = 0.2
     for _ in range(10):
         try:

--- a/services/api/migrations/env.py
+++ b/services/api/migrations/env.py
@@ -12,7 +12,7 @@ from alembic import context  # type: ignore
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 from services.common.base import Base
 
 config = context.config
@@ -25,7 +25,7 @@ if config.config_file_name and os.path.exists(config.config_file_name):
 target_metadata = Base.metadata
 
 
-url = build_url(async_=False)
+url = build_dsn(sync=True)
 config.set_main_option("sqlalchemy.url", url)
 
 connectable = create_engine(url, pool_pre_ping=True)

--- a/services/api/routes/roi.py
+++ b/services/api/routes/roi.py
@@ -15,7 +15,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import create_engine, text, bindparam
 
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 
 router = APIRouter()
 security = HTTPBasic()
@@ -69,7 +69,7 @@ def roi_review(
     category: Optional[str] = None,
     _: str = Depends(_check_basic_auth),
 ):
-    url = build_url(async_=False)
+    url = build_dsn(sync=True)
     engine = create_engine(url)
     with engine.connect() as conn:
         res = conn.execute(ROI_SQL, {"roi_min": roi_min, "vendor": vendor, "category": category})
@@ -106,7 +106,7 @@ async def approve(request: Request, _: str = Depends(_check_basic_auth)) -> dict
     asins = await _extract_asins(request)
     if not asins:
         return {"count": 0}
-    url = build_url(async_=False)
+    url = build_dsn(sync=True)
     engine = create_engine(url)
     with engine.begin() as conn:
         res = conn.execute(UPDATE_SQL, {"asins": asins})

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,6 +1,5 @@
 from .base import Base
 from .models_vendor import Vendor, VendorPrice
 from .keepa import list_active_asins
-from . import llm
 
-__all__ = ["Base", "Vendor", "VendorPrice", "list_active_asins", "llm"]
+__all__ = ["Base", "Vendor", "VendorPrice", "list_active_asins"]

--- a/services/common/db.py
+++ b/services/common/db.py
@@ -1,19 +1,18 @@
 import asyncio
-import os
 from urllib.parse import urlparse, urlunparse
 from asyncpg import create_pool, Pool
 
-_DEFAULT = "postgresql+psycopg://postgres:pass@localhost:5432/awa"
+from .dsn import build_dsn
 
 
 def build_sqlalchemy_url() -> str:
     """Return Postgres URL for SQLAlchemy engines."""
-    return os.getenv("DATABASE_URL", _DEFAULT)
+    return build_dsn(sync=True)
 
 
 def build_asyncpg_dsn() -> str:
     """Return DSN suitable for asyncpg (without driver suffix)."""
-    url = urlparse(build_sqlalchemy_url())
+    url = urlparse(build_dsn(sync=True))
     return urlunparse(
         (
             "postgresql",

--- a/services/common/dsn.py
+++ b/services/common/dsn.py
@@ -2,12 +2,20 @@ import os
 import urllib.parse as _u
 
 
-def build_dsn() -> str:
-    if url := os.getenv("DATABASE_URL"):
-        return url
+def build_dsn(sync: bool = True) -> str:
+    """Return safe DSN.
+
+    sync=True → SQLAlchemy (+psycopg) else plain asyncpg.
+    """
+
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url if sync else url.replace("+psycopg", "")
+
     host = os.getenv("PG_HOST", "localhost")
     port = os.getenv("PG_PORT", "5432")
     user = _u.quote_plus(os.getenv("PG_USER", "postgres"))
     pwd = _u.quote_plus(os.getenv("PG_PASSWORD", "pass"))
     db = os.getenv("PG_DATABASE", "awa")
-    return f"postgresql://{user}:{pwd}@{host}:{port}/{db}"
+    base = f"postgresql://{user}:{pwd}@{host}:{port}/{db}"
+    return base if not sync else base.replace("postgresql://", "postgresql+psycopg://")

--- a/services/common/keepa.py
+++ b/services/common/keepa.py
@@ -1,9 +1,9 @@
 from sqlalchemy import create_engine, text
-from .db_url import build_url
+from .dsn import build_dsn
 
 
 def list_active_asins() -> list[str]:
-    engine = create_engine(build_url(async_=False))
+    engine = create_engine(build_dsn(sync=True))
     with engine.begin() as conn:
         res = conn.execute(text("SELECT asin FROM products"))
         return [r[0] for r in res.fetchall()]

--- a/services/etl/db.py
+++ b/services/etl/db.py
@@ -1,3 +1,3 @@
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 
-DATABASE_URL = build_url(async_=True)
+DATABASE_URL = build_dsn(sync=False)

--- a/services/fees_h10/repository.py
+++ b/services/fees_h10/repository.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 
 _engine: AsyncEngine | None = None
 
@@ -12,7 +12,7 @@ _engine: AsyncEngine | None = None
 def _get_engine() -> AsyncEngine:
     global _engine
     if _engine is None:
-        _engine = create_async_engine(build_url(async_=True), future=True)
+        _engine = create_async_engine(build_dsn(sync=False), future=True)
     return _engine
 
 

--- a/services/logistics_etl/db.py
+++ b/services/logistics_etl/db.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncEngine
 
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 
 
 ENGINE: AsyncEngine | None = None
@@ -12,7 +12,7 @@ ENGINE: AsyncEngine | None = None
 async def init_db() -> None:
     global ENGINE
     if ENGINE is None:
-        ENGINE = create_async_engine(build_url(async_=True), future=True)
+        ENGINE = create_async_engine(build_dsn(sync=False), future=True)
     async with ENGINE.begin() as conn:
         await conn.execute(
             text(

--- a/services/logistics_etl/repository.py
+++ b/services/logistics_etl/repository.py
@@ -5,7 +5,7 @@ from typing import Iterable
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
-from services.common.db_url import build_url
+from services.common.dsn import build_dsn
 
 _engine: AsyncEngine | None = None
 
@@ -13,7 +13,7 @@ _engine: AsyncEngine | None = None
 def _get_engine() -> AsyncEngine:
     global _engine
     if _engine is None:
-        _engine = create_async_engine(build_url(async_=True), future=True)
+        _engine = create_async_engine(build_dsn(sync=False), future=True)
     return _engine
 
 

--- a/services/logistics_etl/tests/conftest.py
+++ b/services/logistics_etl/tests/conftest.py
@@ -1,26 +1,17 @@
 from tests.conftest import *  # noqa
 
-import os
-import urllib.parse
 import pytest
 import sqlalchemy as sa
 from alembic.config import Config
-from alembic import command
+from alembic import command  # type: ignore[attr-defined]
+from services.common.dsn import build_dsn
 
 pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(scope="session")
 def pg_engine():
-    dsn = os.getenv("DATABASE_URL")
-    if not dsn:
-        host = os.getenv("PG_HOST", "localhost")
-        port = os.getenv("PG_PORT", "5432")
-        user = urllib.parse.quote_plus(os.getenv("PG_USER", "postgres"))
-        pwd = urllib.parse.quote_plus(os.getenv("PG_PASSWORD", "pass"))
-        db = os.getenv("PG_DATABASE", "awa")
-        dsn = f"postgresql://{user}:{pwd}@{host}:{port}/{db}"
-    dsn = dsn.replace("postgresql+psycopg://", "postgresql://")
+    dsn = build_dsn(sync=True)
     engine = sa.create_engine(dsn, future=True)
 
     cfg = Config("alembic.ini")

--- a/services/logistics_etl/tests/test_cron.py
+++ b/services/logistics_etl/tests/test_cron.py
@@ -14,7 +14,7 @@ pytest.importorskip("apscheduler")
 respx = pytest.importorskip("respx")
 
 from services.logistics_etl import cron, client, repository  # noqa: E402
-from services.common import db_url  # noqa: E402
+from services.common import db_url, dsn  # noqa: E402
 
 
 @respx.mock
@@ -30,6 +30,7 @@ async def test_job_inserts_and_affects_roi(postgresql_proc, tmp_path, monkeypatc
         f"@{postgresql_proc.host}:{postgresql_proc.port}/{postgresql_proc.dbname}"
     )
     monkeypatch.setattr(db_url, "build_url", lambda async_=False: dsn_async if async_ else dsn_sync)
+    monkeypatch.setattr(dsn, "build_dsn", lambda sync=True: dsn_sync if sync else dsn_async)
     importlib.reload(repository)
     repository._engine = create_async_engine(dsn_async, future=True)
 

--- a/services/price_importer/Dockerfile
+++ b/services/price_importer/Dockerfile
@@ -2,11 +2,14 @@ FROM python:3.11-slim AS builder
 WORKDIR /app
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-COPY requirements.txt ./
+# install python deps for the importer
+COPY services/price_importer/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 FROM python:3.11-slim
 WORKDIR /app
 ENV PATH="/opt/venv/bin:$PATH"
 COPY --from=builder /opt/venv /opt/venv
-COPY . /app/price_importer
+# copy only the modules the importer relies on
+COPY services/common /app/services/common
+COPY services/price_importer /app/price_importer

--- a/services/price_importer/repository.py
+++ b/services/price_importer/repository.py
@@ -5,7 +5,7 @@ from typing import Iterable, cast, Any
 from sqlalchemy import create_engine, select, update, insert
 from sqlalchemy.engine import Engine, CursorResult
 
-from .common.db_url import build_url
+from services.common.dsn import build_dsn
 from .common import Base
 from .common.models_vendor import Vendor, VendorPrice
 
@@ -13,7 +13,7 @@ from .common.models_vendor import Vendor, VendorPrice
 class Repository:
     def __init__(self, engine: Engine | None = None):
         if engine is None:
-            url = build_url(async_=False)
+            url = build_dsn(sync=True)
             engine = create_engine(url, future=True)
         self.engine = engine
         # ensure required tables exist, especially when using SQLite during tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from asyncpg import create_pool
 
 from tests.utils import run_migrations
-from services.common.db import build_sqlalchemy_url, build_asyncpg_dsn
+from services.common.dsn import build_dsn
 
 os.environ.setdefault("ENABLE_LIVE", "0")
 os.environ.setdefault("TESTING", "1")
@@ -24,12 +24,13 @@ PG_DATABASE = os.getenv("PG_DATABASE", "awa")
 
 @pytest.fixture(autouse=True)
 def _set_db_url():
-    os.environ["DATABASE_URL"] = build_sqlalchemy_url()
+    os.environ["DATABASE_URL"] = build_dsn(sync=True)
 
 
 @pytest.fixture
 async def pg_pool(_set_db_url):
-    pool = await create_pool(dsn=build_asyncpg_dsn())
+    async_dsn = os.getenv("PG_ASYNC_DSN") or build_dsn(sync=False)
+    pool = await create_pool(dsn=async_dsn)
     await run_migrations()
     yield pool
     await pool.close()

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1,7 +1,7 @@
 from alembic.config import Config  # type: ignore[attr-defined]
 from alembic import command  # type: ignore[attr-defined]
 from sqlalchemy import create_engine, text
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 import pytest
 
 pytestmark = pytest.mark.integration
@@ -16,7 +16,7 @@ def test_run_migrations(tmp_path, monkeypatch, pg_pool):
     cfg = Config("alembic.ini")
     command.upgrade(cfg, "head")
     command.upgrade(cfg, "head")
-    engine = create_engine(build_sqlalchemy_url())
+    engine = create_engine(build_dsn(sync=True))
     with engine.begin() as conn:
         conn.execute(text("INSERT INTO products(asin) VALUES ('A1')"))
         conn.execute(

--- a/tests/test_dsn.py
+++ b/tests/test_dsn.py
@@ -1,0 +1,8 @@
+import os
+from services.common.dsn import build_dsn
+
+
+def test_build_dsn_sync_suffix():
+    os.environ.pop("DATABASE_URL", None)
+    dsn = build_dsn(sync=True)
+    assert "+psycopg" in dsn

--- a/tests/test_fees_h10.py
+++ b/tests/test_fees_h10.py
@@ -3,7 +3,7 @@ import importlib
 import pytest
 from httpx import Response
 from sqlalchemy import create_engine, text
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 
 pytestmark = pytest.mark.integration
 
@@ -30,7 +30,7 @@ async def test_fetch_fees():
 @pytest.mark.asyncio
 async def test_repository_upsert(tmp_path, monkeypatch, pg_pool):
     importlib.reload(repository)
-    engine = create_engine(build_sqlalchemy_url())
+    engine = create_engine(build_dsn(sync=True))
     with engine.begin() as conn:
         conn.exec_driver_sql(
             """
@@ -73,7 +73,7 @@ async def test_repository_upsert(tmp_path, monkeypatch, pg_pool):
 def test_refresh_fees(tmp_path, monkeypatch, pg_pool):
     importlib.reload(repository)
     importlib.reload(worker)
-    engine = create_engine(build_sqlalchemy_url())
+    engine = create_engine(build_dsn(sync=True))
     with engine.begin() as conn:
         conn.exec_driver_sql(
             """

--- a/tests/test_helium_fees.py
+++ b/tests/test_helium_fees.py
@@ -2,7 +2,7 @@ import importlib
 import os
 import sys
 import types
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 
 
 class FakeCursor:
@@ -32,7 +32,7 @@ class FakeConn:
 
 def test_offline(monkeypatch):
     os.environ.pop("ENABLE_LIVE", None)
-    os.environ["DATABASE_URL"] = build_sqlalchemy_url()
+    os.environ["DATABASE_URL"] = build_dsn(sync=True)
     called = {"n": 0}
 
     def fake_get(url):

--- a/tests/test_helium_fees_ingestor.py
+++ b/tests/test_helium_fees_ingestor.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import types
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 from services.etl import helium_fees_ingestor
 
 
@@ -41,7 +41,7 @@ helium_fees_ingestor.connect = fake_connect
 def test_offline(monkeypatch):
     os.environ["ENABLE_LIVE"] = "0"
     os.environ["HELIUM_API_KEY"] = "k"
-    os.environ["DATABASE_URL"] = build_sqlalchemy_url()
+    os.environ["DATABASE_URL"] = build_dsn(sync=True)
     res = helium_fees_ingestor.main()
     assert res == 0
 
@@ -49,7 +49,7 @@ def test_offline(monkeypatch):
 def test_run_twice(monkeypatch):
     os.environ["ENABLE_LIVE"] = "0"
     os.environ["HELIUM_API_KEY"] = "k"
-    os.environ["DATABASE_URL"] = build_sqlalchemy_url()
+    os.environ["DATABASE_URL"] = build_dsn(sync=True)
 
     helium_fees_ingestor.main()
     helium_fees_ingestor.main()

--- a/tests/test_llm_switch.py
+++ b/tests/test_llm_switch.py
@@ -1,5 +1,5 @@
 import pytest
-from services.common import llm
+import services.common.llm as llm
 
 
 @pytest.mark.asyncio

--- a/tests/test_migration_0004.py
+++ b/tests/test_migration_0004.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine, text
 from alembic.config import Config  # type: ignore[attr-defined]
 from alembic import command  # type: ignore[attr-defined]
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 import pytest
 
 pytestmark = pytest.mark.integration
@@ -18,6 +18,6 @@ def test_upgrade_storage_fee_column_exists(tmp_path, monkeypatch, pg_pool):
     cfg = Config("alembic.ini")
     command.upgrade(cfg, "head")
     command.upgrade(cfg, "head")
-    engine = create_engine(build_sqlalchemy_url())
+    engine = create_engine(build_dsn(sync=True))
     with engine.connect() as conn:
         conn.execute(text("SELECT storage_fee FROM fees_raw LIMIT 1"))

--- a/tests/test_roi_review.py
+++ b/tests/test_roi_review.py
@@ -1,12 +1,12 @@
 from sqlalchemy import create_engine, text
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 import pytest
 
 pytestmark = pytest.mark.integration
 
 
 def _setup_db():
-    engine = create_engine(build_sqlalchemy_url())
+    engine = create_engine(build_dsn(sync=True))
     with engine.begin() as conn:
         # Ensure clean state for deterministic tests
         for tbl in [

--- a/tests/test_sp_fees.py
+++ b/tests/test_sp_fees.py
@@ -1,7 +1,7 @@
 import os
 import types
 import sys
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 
 
 class FakeCursor:
@@ -39,7 +39,7 @@ class FakeSP:
 
 def test_main_offline(monkeypatch):
     os.environ.pop("ENABLE_LIVE", None)
-    os.environ["DATABASE_URL"] = build_sqlalchemy_url()
+    os.environ["DATABASE_URL"] = build_dsn(sync=True)
     fake_api = FakeSP()
     monkeypatch.setitem(
         sys.modules,

--- a/tests/test_sp_fees_ingestor.py
+++ b/tests/test_sp_fees_ingestor.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import types
-from services.common.db import build_sqlalchemy_url
+from services.common.dsn import build_dsn
 from services.etl import sp_fees_ingestor
 
 
@@ -34,7 +34,7 @@ def fake_connect(dsn):
     return FakeConn()
 
 
-sys.modules["pg_utils"] = types.SimpleNamespace(connect=fake_connect)
+sys.modules["pg_utils"] = types.SimpleNamespace(connect=fake_connect)  # type: ignore[assignment]
 sp_fees_ingestor.connect = fake_connect
 
 
@@ -45,6 +45,6 @@ def test_offline(monkeypatch, tmp_path):
     os.environ["SP_CLIENT_SECRET"] = "s"
     os.environ["SELLER_ID"] = "seller"
     os.environ["REGION"] = "EU"
-    os.environ["DATABASE_URL"] = build_sqlalchemy_url()
+    os.environ["DATABASE_URL"] = build_dsn(sync=True)
     res = sp_fees_ingestor.main()
     assert res == 0


### PR DESCRIPTION
## Summary
- create `build_dsn()` helper for sync/async connection strings
- use `build_dsn()` across services and tests
- export both sync and async DSNs in CI workflow
- document database environment matrix
- add unit test for `build_dsn`

## Testing
- `pre-commit run --files services/common/dsn.py alembic/env.py services/api/migrations/env.py tests/conftest.py tests/test_sp_fees.py tests/test_helium_fees.py tests/test_sp_fees_ingestor.py tests/test_roi_review.py tests/integration/test_migrations.py tests/test_helium_fees_ingestor.py tests/test_fees_h10.py tests/test_migration_0004.py tests/test_dsn.py services/etl/db.py services/fees_h10/repository.py services/price_importer/repository.py services/api/db.py services/api/main.py services/api/routes/roi.py services/common/keepa.py services/logistics_etl/repository.py services/logistics_etl/db.py services/logistics_etl/tests/test_cron.py README.md .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757b9e62cc8333a0b3f63a9c4c6ce6