### PR TITLE
Enable pytest asyncio auto mode

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,6 @@ def _port_open(host: str, port: int) -> bool:
         return False
 
 
-@pytest.mark.asyncio
 async def test_health_ok():
     if not _port_open("localhost", 8000):
         pytest.skip("API container is not running on localhost:8000")

--- a/tests/test_fees_h10.py
+++ b/tests/test_fees_h10.py
@@ -13,7 +13,6 @@ from services.fees_h10 import client, repository, worker  # noqa: E402
 
 
 @respx.mock
-@pytest.mark.asyncio
 async def test_fetch_fees():
     route = respx.get(client.BASE.format("A1")).mock(
         return_value=Response(200, json={"fulfillmentFee": 1, "referralFee": 2, "storageFee": 0.5})
@@ -27,7 +26,6 @@ async def test_fetch_fees():
     assert row["storage_fee"] == 0.5
 
 
-@pytest.mark.asyncio
 async def test_repository_upsert(tmp_path, monkeypatch, pg_pool):
     importlib.reload(repository)
     engine = create_engine(build_dsn(sync=True))

--- a/tests/test_llm_switch.py
+++ b/tests/test_llm_switch.py
@@ -1,8 +1,6 @@
-import pytest
 import services.common.llm as llm
 
 
-@pytest.mark.asyncio
 async def test_switch_to_local(monkeypatch):
     async def fake_local(*a, **k):
         return "LOCAL"
@@ -12,7 +10,6 @@ async def test_switch_to_local(monkeypatch):
     assert out == "LOCAL"
 
 
-@pytest.mark.asyncio
 async def test_switch_to_openai(monkeypatch):
     async def fake_openai(*a, **k):
         return "GPT4o"


### PR DESCRIPTION
## Summary
- rely on pytest's asyncio auto mode
- trim unnecessary `@pytest.mark.asyncio` calls in tests

## Testing
- `pre-commit run --files tests/test_llm_switch.py tests/test_fees_h10.py tests/test_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759e9e4d04833387af0763ebc089c7