### PR TITLE
Ensure CSV loads logged in load_log

### DIFF
--- a/services/api/migrations/versions/0011_load_log_table.py
+++ b/services/api/migrations/versions/0011_load_log_table.py
@@ -10,11 +10,12 @@ def upgrade() -> None:
     op.create_table(
         "load_log",
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("file_path", sa.Text, nullable=False),
+        sa.Column("source", sa.Text, nullable=False),
+        sa.Column("target_table", sa.Text, nullable=False),
         sa.Column("inserted_rows", sa.Integer),
         sa.Column("status", sa.Text, nullable=False, server_default="pending"),
         sa.Column(
-            "loaded_at",
+            "inserted_at",
             sa.DateTime(timezone=True),
             server_default=sa.func.now(),
         ),


### PR DESCRIPTION
## Summary
- insert a `_log_load` helper for load_csv and log success or error
- return inserted row counts from `load_csv.main`
- report inserted rows in upload endpoint response
- update migration to define new load_log columns

## Testing
- `ruff --fix .`
- `black .`
- `mypy .`
- `pytest tests/ingest/test_email_watcher.py::test_email_watcher tests/ingest/test_upload.py::test_upload -q`


------
https://chatgpt.com/codex/tasks/task_e_68763d221b208333bb6b6822dd4a9cf4