### PR TITLE
Add Returns ETL and ROI refunds

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1,0 +1,8 @@
+# AWA Blueprint
+
+## Roadmap
+
+v1.2
+
+- Returns-ETL and reimbursements ingestion
+- Ads-ETL next

--- a/README.md
+++ b/README.md
@@ -94,3 +94,13 @@ curl -u admin:pass "http://localhost:8000/roi-review?roi_min=15"
 The emailer and future services call a configurable language model.
 Set `LLM_PROVIDER` to `local` (default) or `openai`. When using
 `openai`, provide `OPENAI_API_KEY` and optionally `OPENAI_MODEL`.
+
+## Manual CSV types
+
+The ingestion CLI auto-detects certain Amazon reports and stores them in
+dedicated tables.
+
+| Report type           | Target table        |
+| --------------------- | ------------------- |
+| `returns_report`      | `returns_raw`       |
+| `reimbursements_report` | `reimbursements_raw` |

--- a/services/api/migrations/versions/0012_returns_reimbursements.py
+++ b/services/api/migrations/versions/0012_returns_reimbursements.py
@@ -1,0 +1,114 @@
+from textwrap import dedent
+from alembic import op  # type: ignore[attr-defined]
+import sqlalchemy as sa
+
+revision = "0012_returns_reimbursements"
+down_revision = "0011_load_log_table"
+branch_labels = depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "returns_raw",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("asin", sa.Text(), nullable=False),
+        sa.Column("order_id", sa.Text()),
+        sa.Column("return_reason", sa.Text()),
+        sa.Column("return_date", sa.Date(), nullable=False),
+        sa.Column("qty", sa.Integer(), nullable=False),
+        sa.CheckConstraint("qty>0", name="ck_returns_qty_pos"),
+        sa.Column("refund_amount", sa.Numeric(), nullable=False),
+        sa.Column("currency", sa.Text()),
+        sa.Column(
+            "inserted_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    op.create_table(
+        "reimbursements_raw",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("asin", sa.Text(), nullable=False),
+        sa.Column("reimb_id", sa.Text()),
+        sa.Column("reimb_date", sa.Date(), nullable=False),
+        sa.Column("qty", sa.Integer()),
+        sa.Column("amount", sa.Numeric(), nullable=False),
+        sa.Column("currency", sa.Text()),
+        sa.Column("reason_code", sa.Text()),
+        sa.Column(
+            "inserted_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    op.execute(
+        dedent(
+            """
+            CREATE MATERIALIZED VIEW v_refund_totals AS
+            SELECT asin,
+                   sum(refund_amount) AS refunds,
+                   sum(qty)           AS refund_qty
+            FROM returns_raw
+            GROUP BY asin;
+            """
+        )
+    )
+
+    op.execute(
+        dedent(
+            """
+            CREATE MATERIALIZED VIEW v_reimb_totals AS
+            SELECT asin,
+                   sum(amount) AS reimbursements
+            FROM reimbursements_raw
+            GROUP BY asin;
+            """
+        )
+    )
+
+    op.execute("refresh materialized view concurrently v_refund_totals;")
+    op.execute("refresh materialized view concurrently v_reimb_totals;")
+
+    op.execute("DROP VIEW IF EXISTS v_roi_full CASCADE")
+    op.execute(
+        dedent(
+            """
+            CREATE VIEW v_roi_full AS
+            SELECT p.asin,
+                   vp.cost,
+                   f.fulfil_fee,
+                   f.referral_fee,
+                   f.storage_fee,
+                   COALESCE(rt.refunds, 0)         AS refunds,
+                   COALESCE(rbt.reimbursements, 0) AS reimbursements,
+                   k.buybox_price,
+                   ROUND(
+                     100 * (
+                       k.buybox_price
+                       - vp.cost
+                       - f.fulfil_fee
+                       - f.referral_fee
+                       - f.storage_fee
+                       - COALESCE(rt.refunds,0)/GREATEST(rt.refund_qty,1)
+                       + COALESCE(rbt.reimbursements,0)/GREATEST(rt.refund_qty,1)
+                     ) / vp.cost,
+                   1) AS roi_pct
+            FROM products p
+            JOIN vendor_prices vp ON vp.sku = p.asin
+            JOIN fees_raw      f  ON f.asin = p.asin
+            JOIN keepa_offers  k  ON k.asin = p.asin
+            LEFT JOIN v_refund_totals rt ON rt.asin = p.asin
+            LEFT JOIN v_reimb_totals rbt ON rbt.asin = p.asin;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS v_roi_full")
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS v_reimb_totals")
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS v_refund_totals")
+    op.drop_table("reimbursements_raw")
+    op.drop_table("returns_raw")

--- a/services/etl/dialects/__init__.py
+++ b/services/etl/dialects/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def normalise_headers(cols: Iterable[str]) -> list[str]:
+    return [c.lower().strip() for c in cols]

--- a/services/etl/dialects/amazon_reimbursements.py
+++ b/services/etl/dialects/amazon_reimbursements.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pandas import DataFrame
+
+from . import normalise_headers
+
+_FIELDS = {
+    "asin": ["asin"],
+    "reimb_id": ["reimbursement id", "reimb id"],
+    "reimb_date": ["reimbursement date", "reimb date"],
+    "qty": ["quantity", "qty"],
+    "amount": ["amount"],
+    "currency": ["currency"],
+    "reason_code": ["reason code"],
+}
+
+
+def normalise(df: DataFrame) -> DataFrame:
+    lower = {c.lower(): c for c in df.columns}
+    for key, options in _FIELDS.items():
+        for opt in options:
+            if opt in lower:
+                df = df.rename(columns={lower[opt]: key})
+                break
+    keep = [c for c in _FIELDS.keys() if c in df.columns]
+    return df[keep]
+
+
+def detect(columns: list[str]) -> bool:
+    cols = set(normalise_headers(columns))
+    return "reimbursement id" in cols or "reimb id" in cols

--- a/services/etl/dialects/amazon_returns.py
+++ b/services/etl/dialects/amazon_returns.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pandas import DataFrame
+
+from . import normalise_headers
+
+_FIELDS = {
+    "asin": ["asin"],
+    "order_id": ["order id", "order_id"],
+    "return_reason": ["return reason", "reason"],
+    "return_date": ["return date"],
+    "qty": ["qty", "quantity"],
+    "refund_amount": ["refund amount", "refund"],
+    "currency": ["currency"],
+}
+
+
+def normalise(df: DataFrame) -> DataFrame:
+    lower = {c.lower(): c for c in df.columns}
+    for key, options in _FIELDS.items():
+        for opt in options:
+            if opt in lower:
+                df = df.rename(columns={lower[opt]: key})
+                break
+    keep = [c for c in _FIELDS.keys() if c in df.columns]
+    return df[keep]
+
+
+def detect(columns: list[str]) -> bool:
+    cols = set(normalise_headers(columns))
+    return "return reason" in cols or "refund amount" in cols

--- a/tests/etl/test_returns_ingest.py
+++ b/tests/etl/test_returns_ingest.py
@@ -1,0 +1,24 @@
+from sqlalchemy import create_engine, text
+from services.common.dsn import build_dsn
+from etl import load_csv
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_returns_ingest(tmp_path):
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text(
+        "ASIN,Order ID,Return Reason,Return Date,Qty,Refund Amount,Currency\n"
+        "A1,O1,Damaged,2024-06-01,1,5.00,EUR\n"
+        "A2,O2,Customer,2024-06-02,1,3.00,EUR\n"
+    )
+    load_csv.main(["--source", str(csv_path), "--table", "auto"])
+
+    engine = create_engine(build_dsn(sync=True))
+    with engine.connect() as conn:
+        cnt = conn.execute(text("SELECT count(*) FROM returns_raw")).scalar()
+        status = conn.execute(text("SELECT status FROM load_log ORDER BY id DESC LIMIT 1")).scalar()
+
+    assert cnt == 2
+    assert status == "success"

--- a/tests/etl/test_roi_after_returns.py
+++ b/tests/etl/test_roi_after_returns.py
@@ -1,0 +1,36 @@
+from sqlalchemy import create_engine, text
+from services.common.dsn import build_dsn
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_roi_after_returns(pg_pool):
+    engine = create_engine(build_dsn(sync=True))
+    with engine.begin() as conn:
+        conn.execute(text("INSERT INTO vendors(id, name) VALUES (1,'ACME') ON CONFLICT DO NOTHING"))
+        conn.execute(text("INSERT INTO products(asin) VALUES ('A1')"))
+        conn.execute(text("INSERT INTO vendor_prices(vendor_id, sku, cost) VALUES (1,'A1',10)"))
+        conn.execute(
+            text(
+                "INSERT INTO fees_raw(asin, fulfil_fee, referral_fee, storage_fee, currency) VALUES ('A1',1,1,1,'EUR')"
+            )
+        )
+        conn.execute(text("INSERT INTO keepa_offers(asin, buybox_price) VALUES ('A1',20)"))
+        conn.execute(
+            text(
+                "INSERT INTO returns_raw(asin, order_id, return_reason, return_date, qty, refund_amount, currency) VALUES ('A1','O1','damaged','2024-06-01',1,5,'EUR')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO reimbursements_raw(asin, reimb_id, reimb_date, qty, amount, currency, reason_code) VALUES ('A1','R1','2024-06-02',1,3,'EUR','goodwill')"
+            )
+        )
+        conn.execute(text("REFRESH MATERIALIZED VIEW v_refund_totals"))
+        conn.execute(text("REFRESH MATERIALIZED VIEW v_reimb_totals"))
+
+    with engine.connect() as conn:
+        roi = conn.execute(text("SELECT roi_pct FROM v_roi_full WHERE asin='A1'"))
+        roi_val = roi.scalar()
+    assert roi_val == 50.0

--- a/tests/fixtures/sample_returns.csv
+++ b/tests/fixtures/sample_returns.csv
@@ -1,0 +1,3 @@
+ASIN,Order ID,Return Reason,Return Date,Qty,Refund Amount,Currency
+A1,O1,Damaged,2024-06-01,1,5.00,EUR
+A2,O2,Customer Return,2024-06-02,1,3.00,EUR


### PR DESCRIPTION
## Summary
- ingest Amazon returns and reimbursements files
- refresh ROI calculation with refunds and reimbursements
- create Alembic migration for new tables and view
- document manual CSV types
- add tests for returns ingestion and ROI logic

## Testing
- `ruff check etl/load_csv.py services/etl/dialects/amazon_returns.py services/etl/dialects/amazon_reimbursements.py services/api/migrations/versions/0012_returns_reimbursements.py tests/etl/test_returns_ingest.py tests/etl/test_roi_after_returns.py`
- `black --check etl/load_csv.py services/etl/dialects/amazon_returns.py services/etl/dialects/amazon_reimbursements.py services/api/migrations/versions/0012_returns_reimbursements.py tests/etl/test_returns_ingest.py tests/etl/test_roi_after_returns.py`
- `mypy services`
- `pytest -q -m integration tests/etl` *(fails: ModuleNotFoundError: No module named 'psycopg')*

------
https://chatgpt.com/codex/tasks/task_e_687642305be08333b0c59ae46d7840c8