### PR TITLE
chore(hardening): add migration tests, coverage gate, ruff+vulture, health-checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule: { interval: "weekly" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,7 @@ jobs:
         run: scripts/wait_pg.sh
       - name: Test
         run: pytest -q
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Docs
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: pip install pydoc-markdown
+      - name: Generate docs
+        run: pydoc-markdown
+      - name: Publish Docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: docs/api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,9 +76,48 @@ jobs:
           PG_PORT: '5432'
           DATA_DIR: ${{ runner.temp }}/awa-data
 
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+
       - name: Dump Postgres logs
         if: always()
         run: |
           echo "::group::postgres container logs"
           docker logs ${{ job.services.postgres.id }} --tail 200
           echo "::endgroup::"
+
+  integration-db:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: pass
+          POSTGRES_DB: awa
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd="pg_isready -U postgres -d awa"
+          --health-interval=5s --health-timeout=5s --health-retries=10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: pip install -r requirements-dev.txt
+      - name: Run migration regression test
+        env:
+          DATABASE_URL: postgresql+psycopg://postgres:pass@localhost:5432/awa
+        run: pytest services/db/tests/test_migrations.py -q
+
+  health-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cp .env.postgres .env
+      - run: docker compose up -d --wait
+      - run: docker compose ps --filter "status=running" --format '{{.Name}} OK'
+      - run: docker compose down -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
     hooks:
       - id: mypy
         args: ["services"]
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: v2.11
+    hooks:
+      - id: vulture
+        args: ["--min-confidence", "80"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 - fix(ci): pipeline passes with updated env defaults
 - drop and recreate refund views to prevent InvalidTableDefinition errors
+- add migration regression test and coverage gate
+- integrate vulture and extended ruff config
+- enable Dependabot updates and docs publishing
+- Docker healthchecks for services
 
 ## v0.3
 - First release with fully passing CI

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 ENTRYPOINT ["python", "keepa_ingestor.py"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # AWA App
+[![codecov](https://codecov.io/gh/your-org/AWA-App/branch/main/graph/badge.svg)](https://codecov.io/gh/your-org/AWA-App)
 
 ## Quick Start
 Repricer API → http://localhost:8100/health

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -1,0 +1,6 @@
+loaders:
+  - type: python
+    search_path: [services]
+renderer:
+  type: markdown
+  output_directory: docs/api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ strict = true
 line-length = 100
 target-version = ["py311"]
 skip-string-normalization = true
+
+[tool.ruff]
+extend-select = ["B", "I", "C4", "T20"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ filterwarnings =
     ignore::DeprecationWarning:asyncio.*
 markers =
     integration: tests that require live database
-addopts = -q -ra
+addopts = -q -ra --cov=services --cov-report=xml --cov-fail-under=85

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,3 +30,4 @@ ruff==0.4.4  # static linter used in CI step "ruff check ."
 sqlalchemy==2.0.29
 testcontainers[postgres]~=4.4
 types-requests==2.32.0.20240602
+pydoc-markdown==4.8.2

--- a/services/alert_bot/Dockerfile
+++ b/services/alert_bot/Dockerfile
@@ -4,3 +4,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY alert_bot.py .
 CMD ["python","alert_bot.py"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -18,3 +18,4 @@ COPY alembic.ini /app/alembic.ini
 COPY services/api/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/db/tests/test_migrations.py
+++ b/services/db/tests/test_migrations.py
@@ -1,0 +1,17 @@
+import subprocess, os, uuid, pytest, psycopg
+
+DB = f"awa_test_{uuid.uuid4().hex[:8]}"
+DSN = f"postgresql://postgres:pass@localhost:5432/{DB}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def tmp_db():
+    subprocess.run(["createdb", DB], check=True)
+    os.environ["DATABASE_URL"] = DSN
+    yield
+    subprocess.run(["dropdb", "--if-exists", DB], check=True)
+
+
+def test_upgrade_and_downgrade():
+    subprocess.run(["alembic", "upgrade", "head"], check=True)
+    subprocess.run(["alembic", "downgrade", "base"], check=True)

--- a/services/etl/Dockerfile
+++ b/services/etl/Dockerfile
@@ -15,3 +15,4 @@ RUN chmod +x /app/wait-for-it.sh /app/entrypoint.sh
 COPY services/etl /app
 COPY keepa_ingestor.py services/etl/fba_fee_ingestor.py /app/
 ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/fees_h10/Dockerfile
+++ b/services/fees_h10/Dockerfile
@@ -11,3 +11,4 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY --from=builder /opt/venv /opt/venv
 COPY services/fees_h10 /app/services/fees_h10
 CMD ["celery", "-A", "services.fees_h10.worker", "beat", "-l", "info"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/llm_server/Dockerfile
+++ b/services/llm_server/Dockerfile
@@ -8,3 +8,4 @@ RUN bash /setup.sh
 COPY app.py /app.py
 EXPOSE 8000
 CMD ["uvicorn","app:app","--host","0.0.0.0","--port","8000"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/logistics_etl/Dockerfile
+++ b/services/logistics_etl/Dockerfile
@@ -11,3 +11,4 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY --from=builder /opt/venv /opt/venv
 COPY services/logistics_etl /app/services/logistics_etl
 CMD ["python", "-m", "logistics_etl"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/price_importer/Dockerfile
+++ b/services/price_importer/Dockerfile
@@ -13,3 +13,4 @@ COPY --from=builder /opt/venv /opt/venv
 # copy only the modules the importer relies on
 COPY services/common /app/services/common
 COPY services/price_importer /app/price_importer
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/repricer/Dockerfile
+++ b/services/repricer/Dockerfile
@@ -5,3 +5,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8100"]
+HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1


### PR DESCRIPTION
## Summary
- add migration regression test to ensure migrations reversible
- require test coverage ≥85% and upload to Codecov
- enforce extra Ruff rules and run vulture
- add Dependabot configuration
- generate docstrings with pydoc-markdown and publish to gh-pages
- add Docker health checks to service containers

## Testing
- `ruff check .`
- `black --check .`
- `vulture . --min-confidence 80`
- `pytest -q` *(fails: createdb: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878165f86e083339c7b5cfbb54ee29f