### PR TITLE
Fix Dockerfiles and add health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-RUN if [ -f requirements-dev.txt ]; then pip install --no-cache-dir -r requirements-dev.txt; fi
+COPY requirements*.txt constraints.txt ./
+ARG CONSTRAINTS=""
+RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
+        pip install --no-cache-dir -r requirements.txt -c "$CONSTRAINTS"; \
+    else \
+        pip install --no-cache-dir -r requirements.txt; \
+    fi
 COPY . .
 ENTRYPOINT ["python", "keepa_ingestor.py"]
 HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1

--- a/services/alert_bot/Dockerfile
+++ b/services/alert_bot/Dockerfile
@@ -2,19 +2,12 @@
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -2,19 +2,12 @@
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 

--- a/services/etl/Dockerfile
+++ b/services/etl/Dockerfile
@@ -2,19 +2,12 @@
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 

--- a/services/fees_h10/Dockerfile
+++ b/services/fees_h10/Dockerfile
@@ -2,19 +2,12 @@
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 

--- a/services/ingest/Dockerfile.email
+++ b/services/ingest/Dockerfile.email
@@ -1,19 +1,12 @@
 FROM python:3.11-slim AS builder
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 

--- a/services/llm_server/Dockerfile
+++ b/services/llm_server/Dockerfile
@@ -1,20 +1,13 @@
 FROM ubuntu:22.04
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN apt-get update && apt-get install -y git build-essential cmake curl python3 python3-pip \
     && if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi \
-    && if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 RUN git clone https://github.com/ggerganov/llama.cpp.git /llama && cd /llama && make LLAMA_CUBLAS=1
 COPY download_and_quantize.sh /setup.sh

--- a/services/llm_server/app.py
+++ b/services/llm_server/app.py
@@ -19,6 +19,11 @@ class Req(BaseModel):
 app = FastAPI()
 
 
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
 @app.post("/llm")
 def gen(r: Req) -> Dict[str, str]:
     try:

--- a/services/logistics_etl/Dockerfile
+++ b/services/logistics_etl/Dockerfile
@@ -2,19 +2,12 @@
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 

--- a/services/price_importer/Dockerfile
+++ b/services/price_importer/Dockerfile
@@ -2,19 +2,12 @@
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 

--- a/services/repricer/Dockerfile
+++ b/services/repricer/Dockerfile
@@ -2,19 +2,12 @@
 FROM python:3.11-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt ./
+COPY requirements*.txt constraints.txt ./
 ARG CONSTRAINTS=""
 RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
         pip install -r requirements.txt -c "$CONSTRAINTS"; \
     else \
         pip install -r requirements.txt; \
-    fi && \
-    if [ -f requirements-dev.txt ]; then \
-        if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-            pip install -r requirements-dev.txt -c "$CONSTRAINTS"; \
-        else \
-            pip install -r requirements-dev.txt; \
-        fi; \
     fi
 COPY . .
 
@@ -24,4 +17,4 @@ WORKDIR /app
 COPY --from=base /usr/local /usr/local
 COPY --from=base /app /app
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8100"]
-HEALTHCHECK CMD curl -fs http://localhost:8000/health || exit 1
+HEALTHCHECK CMD curl -fs http://localhost:8100/health || exit 1


### PR DESCRIPTION
## Summary
- streamline Docker builds by installing only production requirements
- support constraints.txt during install
- fix repricer healthcheck port
- add `/health` endpoint for the llm server

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict services/alert_bot services/api services/common services/db services/etl services/fees_h10 services/ingest services/logistics_etl services/price_importer services/repricer services/returns_etl services/llm_server`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68798cac2a7883339f9ca2bd3be1bf00