### PR TITLE
fix(api+ci): add Alembic & initdb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,10 @@ jobs:
       - name: Wait for Postgres again
         run: scripts/wait_pg.sh
 
-      - name: Install Postgres client & expose initdb
+      - name: Install PostgreSQL server (initdb)
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-client
+          sudo apt-get install -y postgresql
           echo "/usr/lib/postgresql/$(pg_config --version | cut -d' ' -f2 | cut -d'.' -f1,2)/bin" >> $GITHUB_PATH
       - name: Dockerfile build sanity
         run: pytest -q tests/test_docker_build.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,10 @@ jobs:
       - run: npm run build --if-present
         working-directory: web
 
-      - name: Install Postgres client & expose initdb
+      - name: Install PostgreSQL server (initdb)
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-client
+          sudo apt-get install -y postgresql
           echo "/usr/lib/postgresql/$(pg_config --version | cut -d' ' -f2 | cut -d'.' -f1,2)/bin" >> $GITHUB_PATH
 
 
@@ -136,10 +136,10 @@ jobs:
           if [ ! -f tests/db/test_migrations.py ]; then
             echo "::error ::migration test missing" && exit 1
           fi
-      - name: Install Postgres client & expose initdb
+      - name: Install PostgreSQL server (initdb)
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-client
+          sudo apt-get install -y postgresql
           echo "/usr/lib/postgresql/$(pg_config --version | cut -d' ' -f2 | cut -d'.' -f1,2)/bin" >> $GITHUB_PATH
 
       - name: Run migration regression test

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,2 +1,6 @@
 uvicorn==0.29.0
 pydantic-settings==2.2.1
+fastapi==0.111.0
+sqlalchemy==2.0.*
+alembic==1.13.*
+psycopg[binary]==3.1.*


### PR DESCRIPTION
## Summary
- install API dependencies for alembic migrations
- update CI to install the full PostgreSQL server so `initdb` is available

## Testing
- `ruff check .`
- `ruff format --check .`
- `black --check .` *(fails: would reformat many files)*
- `mypy services`
- `npm ci && npm test --silent`
- `pytest tests/db/test_migrations.py -vv` *(fails: initdb cannot run as root)*


------
https://chatgpt.com/codex/tasks/task_e_687aee06e2cc8333a0d07447a5455ef8