### PR TITLE
Fix test migrations in CI

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,9 @@
+PG_USER=postgres
+PG_PASSWORD=pass
+PG_DATABASE=awa
+PG_HOST=localhost
+PG_PORT=5432
+DATABASE_URL=postgresql+psycopg://postgres:pass@localhost:5432/awa
+DATA_DIR=/tmp/awa-data
+ENABLE_LIVE=0
+TESTING=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Load env
+        run: cat .env.ci >> $GITHUB_ENV
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -17,6 +19,8 @@ jobs:
           cache-dependency-path: requirements-dev.txt
       - name: Install deps
         run: pip install -r requirements-dev.txt
+      - name: Run migrations
+        run: alembic -c services/api/alembic.ini upgrade head
       - name: Ruff
         run: ruff check . --output-format=github
       - name: Format


### PR DESCRIPTION
## Summary
- auto-run migrations when tests need a database
- load `.env.ci` in CI and run Alembic upgrade before pytest
- ensure test config uses API Alembic config

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883752d86a883339f60e707b6de4583