### PR TITLE
Fix compose health stage to use SHA images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             --build-arg TZ_CACHE_BUST=${{ github.sha }} \
             --load services/api
       - name: Push image
+        if: github.ref == 'refs/heads/main'
         run: docker push ghcr.io/${{ github.repository }}/api:${{ github.sha }}
 
   compose-health:
@@ -72,9 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo "GIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
-      - run: echo "OWNER_LC=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-      - run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --wait --no-build
+      - run: echo "GITHUB_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
+      - run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --wait --no-build --pull never
       - run: docker compose ps
       - name: Gather logs
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: if [ ! -f .env ]; then cp .env.postgres .env; fi
-      - run: docker compose build --pull --build-arg TZ_CACHE_BUST=${{ github.sha }}
+      - run: docker compose build --build-arg TZ_CACHE_BUST=${{ github.sha }}
       - run: docker compose up -d --wait
       - name: Ensure services healthy
         run: |

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
 services:
   api:
-    image: ghcr.io/${OWNER_LC}/api:${GIT_SHA}
-    pull_policy: never
+    image: ghcr.io/${GITHUB_REPOSITORY}/api:${GITHUB_SHA}
+    pull_policy: never  # Compose v2.23+: never contact registry


### PR DESCRIPTION
## Summary
- update docker-compose override to reference GITHUB_SHA
- disable pulls in health checks
- push images only from main branch
- drop `--pull` in health-check job

## Testing
- `ruff check .`
- `ruff format --check .`
- `python -m mypy services`
- `pytest -q`
- `pip install -r requirements-dev.txt`

------
https://chatgpt.com/codex/tasks/task_e_6884399789b483339856210e163a2893