### PR TITLE
Refactor compose health CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
             --tag ghcr.io/${{ github.repository }}/api:${{ github.sha }} \
             --build-arg TZ_CACHE_BUST=${{ github.sha }} \
             --load services/api
-      - name: Push image
-        if: github.ref == 'refs/heads/main'
-        run: docker push ghcr.io/${{ github.repository }}/api:${{ github.sha }}
 
   compose-health:
     needs: container-build
@@ -74,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo "GITHUB_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
-      - run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --wait --no-build --pull never
+      - run: docker compose -f docker-compose.ci.yml up -d --wait --no-build --pull never
       - run: docker compose ps
       - name: Gather logs
         if: failure()
@@ -85,3 +82,33 @@ jobs:
         with:
           name: docker-logs
           path: logs.txt
+
+  push-image:
+    if: github.ref == 'refs/heads/main'
+    needs: compose-health
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push image
+        run: docker push ghcr.io/${{ github.repository }}/api:${{ github.sha }}
+
+  upload-coverage:
+    needs: compose-health
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
+      - uses: codecov/codecov-action@v4
+        if: success() && env.CODECOV_TOKEN != ''
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,3 +2,6 @@ services:
   api:
     image: ghcr.io/${GITHUB_REPOSITORY}/api:${GITHUB_SHA}
     pull_policy: never  # Compose v2.23+: never contact registry
+  postgres:
+    image: postgres:15
+    command: ["postgres","-c","timezone=UTC"]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,7 @@
 services:
   api:
     image: ghcr.io/${GITHUB_REPOSITORY}/api:${GITHUB_SHA}
-    pull_policy: never  # Compose v2.23+: never contact registry
+    pull_policy: never            # requires Compose ≥2.23; otherwise omit and rely on --pull never
   postgres:
     image: postgres:15
-    command: ["postgres","-c","timezone=UTC"]
+    command: ["postgres", "-c", "timezone=UTC"]

--- a/setup_commands.sh
+++ b/setup_commands.sh
@@ -60,7 +60,7 @@ else
     echo "VITE_API_URL=https://awapricer.lan/api" > web/.env
 fi
 
-docker compose pull && docker compose build && docker compose up -d --wait || exit 1
+docker compose build && docker compose up -d --wait || exit 1
 
 curl -f http://localhost:8000/health >/dev/null || { echo "Health check failed" >&2; exit 1; }
 


### PR DESCRIPTION
## Summary
- remove compose pull from helper script
- build SHA-tagged API image in CI
- run compose-health using the built image
- add push-image and upload-coverage jobs
- reference commit images in docker-compose.ci.yml

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68843d6fab288333ba1d8f92a3c53eda