### PR TITLE
Fix CI DB creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Load env
-        run: cat .env.ci >> $GITHUB_ENV
+        run: cat .env.ci >> "$GITHUB_ENV"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -29,11 +29,11 @@ jobs:
       - name: Install deps
         run: pip install -r requirements-dev.txt
       - name: Wait for DB
-        run: bash services/etl/wait-for-it.sh localhost:5432 -t 30
-      - name: Create DB for unit tests
-        run: psql -h localhost -U postgres -c "CREATE DATABASE awa;"
+        run: bash services/etl/wait-for-it.sh "$PG_HOST:5432" -t 30
+      - name: Create test database
+        run: psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -c "CREATE DATABASE $PG_DATABASE;"
         env:
-          PGPASSWORD: pass
+          PGPASSWORD: ${{ env.PG_PASSWORD }}
       - name: Run migrations
         run: alembic -c services/api/alembic.ini upgrade head
       - name: Ruff
@@ -44,6 +44,10 @@ jobs:
           args: "format --check ."
       - name: Type check
         run: python -m mypy services || true
+      - name: Ensure test DB exists
+        run: psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -c "CREATE DATABASE $PG_DATABASE;"
+        env:
+          PGPASSWORD: ${{ env.PG_PASSWORD }}
       - name: Pytest
         run: pytest -q
       - uses: actions/upload-artifact@v4

--- a/tests/test_wait_for_it.py
+++ b/tests/test_wait_for_it.py
@@ -5,16 +5,7 @@ import subprocess
 def test_wait_for_it_exec() -> None:
     script = pathlib.Path("services/etl/wait-for-it.sh")
     proc = subprocess.run(
-        [
-            "bash",
-            str(script),
-            "localhost:1",
-            "-t",
-            "1",
-            "--",
-            "echo",
-            "ok",
-        ],
+        ["bash", str(script), "localhost:1", "-t", "1", "--", "echo", "ok"],
         capture_output=True,
     )
     assert proc.returncode == 0


### PR DESCRIPTION
## Summary
- create test database with env vars in CI before migrations
- ensure DB exists again before pytest
- format tests/test_wait_for_it.py

## Testing
- `ruff check .`
- `ruff format --check .`
- `python -m mypy services`
- `pytest tests/test_dsn.py -q` *(fails: Coverage failure)*

------
https://chatgpt.com/codex/tasks/task_e_68854d4d02188333882a628f4f0eb69d