### PR TITLE
chore(ci): persist CI logs and guide agents to use them

### DIFF
--- a/.github/workflows/publish-logs.yml
+++ b/.github/workflows/publish-logs.yml
@@ -1,0 +1,73 @@
+name: Publish logs
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'ci-logs/**'
+  pull_request:
+    paths-ignore:
+      - 'ci-logs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-logs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  collect-logs:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare logs
+        run: |
+          mkdir -p .logs
+          if [ -d test-results ]; then cp -r test-results .logs/; fi
+          echo "$GITHUB_REPOSITORY" > .logs/repo.txt
+          echo "$GITHUB_SHA" > .logs/commit.txt
+          echo "$GITHUB_RUN_ID" > .logs/run_id.txt
+          echo "$GITHUB_REF" > .logs/ref.txt
+          date -u +"%Y-%m-%dT%H:%M:%SZ" > .logs/generated_at_utc.txt
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-logs
+          path: .logs
+          retention-days: 7
+
+  publish-logs:
+    needs: collect-logs
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: run-logs
+          path: ci-logs/_tmp
+      - name: Replace repo logs
+        run: |
+          rm -rf ci-logs/latest
+          mkdir -p ci-logs
+          mv ci-logs/_tmp ci-logs/latest
+      - name: Commit and push
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+        run: |
+          git add ci-logs
+          if git diff --staged --quiet; then
+            echo "no changes"
+          else
+            git commit -m "ci: update persisted logs for ${{ github.sha }} [skip ci]"
+            git push
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,58 @@ Agents are first added to the local docker-compose environment for development. 
 2. Open a Codex PR describing the purpose of the agent.
 3. Add tests covering the expected behaviour and ensure `pre-commit` and `pytest` succeed.
 4. Update CI and docker-compose files so the agent runs in each environment.
+
+Agent operating mode: log-driven debugging
+
+Goal
+Use the repository’s persisted CI logs to identify failing errors first, then implement the smallest safe code change to fix them.
+
+Primary inputs
+1) Directory ci-logs/latest containing unzipped logs from the most recent workflow run.
+2) If ci-logs/latest is missing, scan ci-logs for the most recently modified subfolder and use that instead.
+3) Treat any files with extensions .log, .txt, .out, .err, .json, .xml, .junit, .tap as logs. Ignore archives because the workflow already unpacks artifacts.
+
+What to extract from logs
+1) The first hard failure that stops the pipeline. Prefer explicit error markers like Traceback, Exception, ERROR, FATAL, npm ERR!, TypeError, ReferenceError, Cannot find module, undefined reference, segmentation fault, AssertionError, test failures from pytest/jest/go test/maven/gradle.
+2) For that failure collect a minimal excerpt: up to 200 lines ending at the failure plus up to 100 lines of preceding context.
+3) Paths and line numbers of implicated source files, failing test names, command that failed, exit code.
+4) If multiple independent failures exist, handle them one by one in chronological order of appearance in the logs.
+
+Procedure
+1) Locate logs: read ci-logs/latest. If empty or missing, report this and stop.
+2) Parse logs and write a short triage summary in memory with keys: failure_kind, primary_file, line, failing_command, shortest_repro, stack_excerpt.
+3) Open the implicated source file(s) and reason about the smallest change that fixes the root cause without weakening tests.
+4) Implement the change. Do not change tests unless the test is objectively incorrect or contradicts the documented behavior.
+5) If a deterministic quick check is available from the logs (for example a unit test command), run that command locally when permitted; otherwise, include exact commands for maintainers to run.
+6) Update any related docs or configuration if the root cause is configuration or missing dependency.
+7) Prepare a commit with a clear message and a concise PR body.
+
+Constraints
+1) Never delete or rewrite logs; do not commit changes under ci-logs.
+2) Keep changes minimal and focused on the identified failure.
+3) Preserve code style and lint rules already used in the repo.
+4) Do not introduce secrets or modify CI triggers.
+5) Do not add [skip ci] to fix commits; it is only used by the log-publishing workflow.
+
+Deliverables
+1) A single focused commit or PR that fixes the failure.
+2) PR body sections:
+   Summary: one paragraph describing the user-visible issue.
+   Root cause: one paragraph referencing files/lines.
+   Fix: bullet list of code changes.
+   Repro steps: exact commands reproduced from logs to validate.
+   Risk: potential side effects and why they are acceptable.
+   Links: paths to the log files used, for example ci-logs/latest/build.log.
+3) Add a triage note file at docs/ci-triage.md if the repo uses such docs; otherwise include the triage content in the PR body.
+
+Success criteria
+1) The specific failing error from ci-logs/latest is no longer present in the next CI run.
+2) All previously passing tests remain green.
+3) The PR body references the exact log filenames and contains a minimal excerpt of the failure.
+4) The fix is the smallest reasonable change and adheres to the project’s style.
+5) No files under ci-logs are modified by the fix.
+
+Optional heuristics
+1) Prefer the newest timestamped log if multiple versions of the same tool exist.
+2) For test suites, extract the first failing test case name and only address that failure initially.
+3) For compiler or linter errors, jump to the highest-level message that points to a source file and line; ignore cascading duplicates.


### PR DESCRIPTION
## Summary
- publish logs from CI runs and commit them under `ci-logs/latest`
- document log-driven debugging workflow for agents

## Testing
- `pre-commit run --files .github/workflows/publish-logs.yml AGENTS.md` *(fails: Username for 'https://github.com')*
- `pytest -q` *(fails: 12 errors during collection)*

If repository protections prevent pushes from `GITHUB_TOKEN`, a maintainer can swap checkout to use a PAT with `contents:write`.

------
https://chatgpt.com/codex/tasks/task_e_68a07422cc808333928ff58784e071ec