### PR TITLE
chore(ci): switch log aggregator from gh cli to REST to avoid 404 and persist logs

### DIFF
--- a/.github/workflows/publish-logs.yml
+++ b/.github/workflows/publish-logs.yml
@@ -24,54 +24,82 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Wait for all workflows to finish for this SHA
+      - name: Wait for all workflows to finish for this SHA (only on workflow_run)
+        if: ${{ github.event_name == 'workflow_run' }}
         run: |
           python3 - <<'PY'
-          import os, json, subprocess, time
-          repo=os.environ["OWNER_REPO"]; sha=os.environ["HEAD_SHA"]; targets=json.loads(os.environ["TARGETS"])
+          import os, json, urllib.request, urllib.parse, time
+          repo=os.environ["OWNER_REPO"]
+          sha=os.environ["HEAD_SHA"]
+          targets=json.loads(os.environ["TARGETS"])
+          headers={
+            "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "gha-log-collector"
+          }
+          def api(path, params=None):
+            url="https://api.github.com/"+path
+            if params: url += "?" + urllib.parse.urlencode(params)
+            req=urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req) as r:
+              return json.load(r)
           deadline=time.time()+1200
-          def runs():
-              out=subprocess.check_output(["gh","api",f"repos/{repo}/actions/runs","-f",f"head_sha={sha}"])
-              return json.loads(out)["workflow_runs"]
           while True:
-              all_done=True
-              for t in targets:
-                  rs=[r for r in runs() if r["name"]==t]
-                  if not rs: 
-                      continue
-                  st=set(r["status"] for r in rs)
-                  if any(s in ("queued","in_progress","requested","waiting") for s in st):
-                      all_done=False
-                      break
-              if all_done or time.time()>deadline:
-                  break
-              time.sleep(15)
+            runs=api(f"repos/{repo}/actions/runs", {"head_sha": sha, "per_page": 100}).get("workflow_runs",[])
+            pending=False
+            for t in targets:
+              st=[r["status"] for r in runs if r["name"]==t]
+              if any(s in ("queued","in_progress","requested","waiting") for s in st):
+                pending=True
+                break
+            if not pending or time.time()>deadline:
+              break
+            time.sleep(15)
           PY
       - name: Download and unpack logs
         run: |
-          rm -rf ci-logs/_tmp ci-logs/latest
-          mkdir -p ci-logs/_tmp
           python3 - <<'PY'
-          import os, json, subprocess, zipfile, shutil
-          repo=os.environ["OWNER_REPO"]; sha=os.environ["HEAD_SHA"]; targets=json.loads(os.environ["TARGETS"])
-          out=subprocess.check_output(["gh","api",f"repos/{repo}/actions/runs","-f",f"head_sha={sha}"])
-          runs=json.loads(out)["workflow_runs"]
-          dest="ci-logs/_tmp"
-          os.makedirs(dest, exist_ok=True)
+          import os, json, urllib.request, urllib.parse, zipfile, shutil
+          repo=os.environ["OWNER_REPO"]
+          sha=os.environ["HEAD_SHA"]
+          targets=json.loads(os.environ["TARGETS"])
+          headers={
+            "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "gha-log-collector"
+          }
+          def api_json(path, params=None):
+            url="https://api.github.com/"+path
+            if params: url += "?" + urllib.parse.urlencode(params)
+            req=urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req) as r:
+              return json.load(r)
+          def api_bytes(path):
+            url="https://api.github.com/"+path
+            req=urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req) as r:
+              return r.read()
+          runs=api_json(f"repos/{repo}/actions/runs", {"head_sha": sha, "per_page": 100}).get("workflow_runs",[])
+          tmp="ci-logs/_tmp"
+          shutil.rmtree("ci-logs/latest", ignore_errors=True)
+          shutil.rmtree(tmp, ignore_errors=True)
+          os.makedirs(tmp, exist_ok=True)
           for t in targets:
-              cand=[r for r in runs if r["name"]==t and r["conclusion"] in ("success","failure","cancelled","timed_out","action_required","neutral","skipped")]
-              if not cand:
-                  continue
-              cand.sort(key=lambda r: r["run_number"], reverse=True)
-              rid=cand[0]["id"]
-              zip_path=f"{dest}/{t}-{rid}.zip"
-              subprocess.check_call(["gh","api",f"repos/{repo}/actions/runs/{rid}/logs","--output",zip_path])
-              unpack_dir=f"{dest}/{t}"
-              os.makedirs(unpack_dir, exist_ok=True)
-              with zipfile.ZipFile(zip_path) as z:
-                  z.extractall(unpack_dir)
-              os.remove(zip_path)
-          shutil.move("ci-logs/_tmp","ci-logs/latest")
+            cand=[r for r in runs if r["name"]==t and r["conclusion"] in ("success","failure","cancelled","timed_out","action_required","neutral","skipped")]
+            if not cand:
+              continue
+            cand.sort(key=lambda r: r["run_number"], reverse=True)
+            rid=cand[0]["id"]
+            zbytes=api_bytes(f"repos/{repo}/actions/runs/{rid}/logs")
+            zpath=os.path.join(tmp, f"{t}-{rid}.zip")
+            with open(zpath,"wb") as f: f.write(zbytes)
+            outdir=os.path.join(tmp, t)
+            os.makedirs(outdir, exist_ok=True)
+            with zipfile.ZipFile(zpath) as z: z.extractall(outdir)
+            os.remove(zpath)
+          shutil.move(tmp, "ci-logs/latest")
           PY
       - name: Commit and push
         if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}


### PR DESCRIPTION
### Summary
Switch log aggregation workflow to use direct REST API calls so logs persist even when gh cli endpoints return 404.

### Root cause
The previous log collector invoked `gh api` to poll and download job logs. Those requests returned 404 for some runs, causing the workflow to fail early and skip committing logs.

### Fix
- Poll GitHub REST API via `urllib` to wait for targeted workflows to complete.
- Download each run's logs with `urllib`, unpack them, and move them into `ci-logs/latest`.

### Repro steps
1. Trigger CI, test and Docs workflows.
2. After they complete, run the "Collect all workflow logs" workflow.
3. Verify a commit is created containing `ci-logs/latest` with logs for each workflow.

### Risk
Low. The workflow still uses `GITHUB_TOKEN`; only internal API calls changed from gh cli to Python.

### Links
- `.github/workflows/publish-logs.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a0e9ad2ffc8333904780928bbf46f4