### PR TITLE
Fix Docker builds and logistics ETL runtime

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,5 +1,6 @@
 FROM postgres:16
-RUN apt-get update && apt-get install -y locales \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list \
+    && apt-get update && apt-get install -y locales \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 ENV LANG en_US.UTF-8

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -24,7 +24,8 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app:/app/services
 WORKDIR /app
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends tzdata postgresql-client curl \
     && rm -rf /var/lib/apt/lists/*
 ENV TZ=UTC

--- a/services/etl/Dockerfile
+++ b/services/etl/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /app
 COPY --from=base /usr/local /usr/local
 COPY --from=base /app /app
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends tzdata \
     && rm -rf /var/lib/apt/lists/*
 ENV TZ=UTC

--- a/services/logistics_etl/__main__.py
+++ b/services/logistics_etl/__main__.py
@@ -2,6 +2,11 @@ import asyncio
 
 from .cron import start
 
-if __name__ == "__main__":
+
+async def _run() -> None:
     start()
-    asyncio.get_event_loop().run_forever()
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(_run())

--- a/services/repricer/Dockerfile
+++ b/services/repricer/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /app
 COPY --from=base /usr/local /usr/local
 COPY --from=base /app /app
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends tzdata \
     && rm -rf /var/lib/apt/lists/*
 ENV TZ=UTC


### PR DESCRIPTION
## Summary
- use HTTPS Debian mirrors so Docker builds can fetch dependencies
- run logistics ETL scheduler via `asyncio.run` to keep the service alive

## Root Cause
- Dockerfiles used HTTP Debian mirror URLs, which are blocked in CI, causing `apt-get` to fail during image builds.
- `services/logistics_etl/__main__.py` relied on `asyncio.get_event_loop()`, which raises a `RuntimeError` under Python 3.12, causing the container to exit immediately.

## Fix
- replace `http://deb.debian.org` with `https://deb.debian.org` in service Dockerfiles
- refactor logistics ETL entrypoint to use `asyncio.run` and wait on an `asyncio.Event`

## Repro Steps
- `docker build -f services/api/Dockerfile services/api`
- `python -m services.logistics_etl`

## Risk
- Low: changes are limited to build scripts and the ETL entrypoint. Tested locally.

## Links
- ci-logs/latest/CI/compose-health/4_Run export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1.txt
- ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt

------
https://chatgpt.com/codex/tasks/task_e_68a0f33fc74c833389b7c4667c345ba2