### PR TITLE
Fix fees_h10 container import path

### DIFF
--- a/services/fees_h10/Dockerfile
+++ b/services/fees_h10/Dockerfile
@@ -2,21 +2,26 @@
 FROM python:3.12-slim AS base
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY requirements*.txt constraints.txt ./
+# Install dependencies first to leverage Docker layer caching.  The service
+# sources live under /app/fees_h10 in the final image so that Python can
+# import the `fees_h10` package.
+COPY requirements*.txt constraints.txt ./fees_h10/
 ARG CONSTRAINTS=""
-RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
-        pip install -r requirements.txt -c "$CONSTRAINTS"; \
+RUN if [ -n "$CONSTRAINTS" ] && [ -f "fees_h10/$CONSTRAINTS" ]; then \
+        pip install -r fees_h10/requirements.txt -c fees_h10/$CONSTRAINTS; \
     else \
-        pip install -r requirements.txt; \
+        pip install -r fees_h10/requirements.txt; \
     fi
-COPY . .
+# Copy the application code into a package directory and place the start
+# script at the image root.
+COPY . ./fees_h10
+COPY start.sh ./start.sh
 
 FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY --from=base /usr/local /usr/local
 COPY --from=base /app /app
-COPY start.sh ./start.sh
 RUN chmod +x ./start.sh
 ENTRYPOINT ["./start.sh"]
 HEALTHCHECK CMD ["celery", "--help"]

--- a/services/fees_h10/start.sh
+++ b/services/fees_h10/start.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -e
-export PYTHONPATH="/app:/app/services:${PYTHONPATH}"
+# Ensure the service package is importable when running inside the
+# container.  In the built image the code lives under /app/fees_h10, so we
+# only need /app on PYTHONPATH.
+export PYTHONPATH="/app:${PYTHONPATH}"
 exec celery -A fees_h10.worker beat -l info


### PR DESCRIPTION
## Summary
- ensure fees_h10 code is packaged so Celery can import it
- align start script PYTHONPATH with container layout

## Root Cause
- The compose-health workflow failed because the `fees_h10` service container exited with status 2 when Celery tried to import `fees_h10.worker`. The Dockerfile copied the service files directly to `/app`, so the `fees_h10` package was missing and Celery couldn't load it.

## Fix
- Copy service sources into `/app/fees_h10` during image build
- Limit `PYTHONPATH` to `/app` in `start.sh` so the package resolves correctly

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait --no-build --pull always`
- `pytest tests/test_fees_h10.py::test_fetch_fees -m integration -q --cov=services --cov-fail-under=0`

## Risk
- Low: changes are isolated to the fees_h10 service build and startup scripts.

## Links
- ci-logs/latest/CI/3_compose-health.txt


------
https://chatgpt.com/codex/tasks/task_e_68a11c0013ec8333b119a7432c4b5191