### PR TITLE
Guard logistics ETL upsert when no rates available

### DIFF
--- a/services/logistics_etl/cron.py
+++ b/services/logistics_etl/cron.py
@@ -6,7 +6,8 @@ from .repository import upsert_many
 
 async def job() -> None:
     rows = await fetch_rates()
-    await upsert_many(rows)
+    if rows:
+        await upsert_many(rows)
 
 
 def start() -> None:


### PR DESCRIPTION
## Summary
- prevent logistics ETL from crashing when no freight rates are returned

## Root Cause
- `cron.job` always attempted to upsert fetched freight rates; when the upstream API responded with no rows, the database insert received an empty list and raised, stopping the container during health checks

## Fix
- skip the upsert when `fetch_rates()` returns no data

## Repro Steps
- `pip install -r requirements-dev.txt`
- `pytest -q --cov=services`

## Risk
- Low: change only affects the logistics ETL job and merely guards against empty inputs

## Links
- ci-logs/latest/test/2_health-checks.txt


------
https://chatgpt.com/codex/tasks/task_e_68a1cb00c8b883338285060bb503a8ab