### PR TITLE
Fix copy loader import order for ruff

### DIFF
--- a/services/ingest/copy_loader.py
+++ b/services/ingest/copy_loader.py
@@ -4,8 +4,8 @@ import io
 from typing import Optional, Sequence
 
 import pandas as pd
-from sqlalchemy.engine import Engine
 from psycopg2 import sql
+from sqlalchemy.engine import Engine
 
 
 def _ensure_ident(name: str) -> sql.Identifier:
@@ -91,7 +91,9 @@ def copy_df_via_temp(
                         )
                         ins = sql.SQL(
                             "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO UPDATE SET {}"
-                        ).format(tgt, cols_csv, cols_csv, stg, conflict_list, set_clause)
+                        ).format(
+                            tgt, cols_csv, cols_csv, stg, conflict_list, set_clause
+                        )
                     else:
                         ins = sql.SQL(
                             "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO NOTHING"

--- a/tests/etl/test_copy_loader.py
+++ b/tests/etl/test_copy_loader.py
@@ -20,7 +20,9 @@ def engine():
     engine = create_engine(TEST_DSN)
     with engine.begin() as conn:
         conn.execute(text("CREATE SCHEMA IF NOT EXISTS test_ingest"))
-        conn.execute(text("DROP TABLE IF EXISTS test_ingest.reimbursements_raw CASCADE"))
+        conn.execute(
+            text("DROP TABLE IF EXISTS test_ingest.reimbursements_raw CASCADE")
+        )
         conn.execute(
             text(
                 """
@@ -163,7 +165,9 @@ def test_append_only(engine):
         columns=cols,
     )
     with engine.connect() as conn:
-        cnt = conn.execute(text("SELECT count(*) FROM test_ingest.returns_raw")).scalar()
+        cnt = conn.execute(
+            text("SELECT count(*) FROM test_ingest.returns_raw")
+        ).scalar()
     assert cnt == 4
 
 


### PR DESCRIPTION
## Summary
- fix unsorted import in `copy_loader` that broke linting
- format test for `copy_loader` so `ruff format --check` passes

## Root Cause
- `services/ingest/copy_loader.py` had third-party imports out of order, causing `ruff` to fail during the **Check code formatting** step in CI.

## Fix
- reorder `pandas`, `psycopg2`, and `sqlalchemy` imports
- apply `ruff format` to `copy_loader` and its test module

## Repro Steps
1. `python -m pip install -r requirements-dev.txt`
2. `ruff check .`
3. `ruff format --check .`
4. `pytest -q`

## Risk
- Low: changes are import and formatting only.

## Links
- ci-logs/latest/CI/unit/7_Check code formatting.txt


------
https://chatgpt.com/codex/tasks/task_e_68a1fc4ddeb88333af6da22585d25cbc