### PR TITLE
fix: include API routers in Docker image

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -11,6 +11,8 @@ COPY services/api/ ./services/api
 COPY services/common/ ./services/common
 COPY services/ingest/ ./services/ingest
 COPY services/etl/ ./services/etl
+# copy shared API routers
+COPY api/ ./api
 # configuration files for migrations
 COPY services/api/alembic.ini ./alembic.ini
 COPY alembic/ ./alembic/


### PR DESCRIPTION
## Summary
- copy shared `api` routers into the API Docker image to prevent startup crash

## Root Cause
- `services/api/Dockerfile` did not copy the top-level `api` package used by `services.api.main`, causing the API container to exit when the module was missing during `docker compose up`【F:ci-logs/latest/CI/3_compose-health.txt†L1510-L1529】【F:services/api/Dockerfile†L10-L15】

## Fix
- add `COPY api/ ./api` so the image contains the required routers

## Repro Steps
- `ruff check .`
- `ruff format --check .`
- `pytest`

## Risk
- Low: only affects Docker image contents for the API service; no code logic changed.

## Links
- ci-logs/latest/CI/3_compose-health.txt


------
https://chatgpt.com/codex/tasks/task_e_68a214c37eb883338e60704251bf7bbf