### PR TITLE
Sort imports and fix health-check script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
         run: |
           export COMPOSE_DOCKER_CLI_BUILD=1
           export DOCKER_BUILDKIT=1
-          docker compose ps --format '{{.Name}} {{.State.Health.Status}}' | tee ps.log
+          docker compose ps --format '{{.Name}} {{.State}} {{.Health}}' | tee ps.log
           if grep -E '\b(unhealthy|starting|exited)\b' ps.log; then
             cat ps.log
             exit 1

--- a/services/api/migrations/versions/0026_amazon_new_reports.py
+++ b/services/api/migrations/versions/0026_amazon_new_reports.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+
 from alembic import op
 
 revision = "0026_amazon_new_reports"
@@ -115,17 +116,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        "DROP INDEX IF EXISTS uq_settlements_txn_raw_transaction_id"
-    )
+    op.execute("DROP INDEX IF EXISTS uq_settlements_txn_raw_transaction_id")
     op.drop_index(
         "idx_settlements_txn_raw_settlement",
         table_name="settlements_txn_raw",
         if_exists=True,
     )
-    op.execute(
-        "DROP INDEX IF EXISTS brin_settlements_txn_raw_posted_date"
-    )
+    op.execute("DROP INDEX IF EXISTS brin_settlements_txn_raw_posted_date")
     op.drop_table("settlements_txn_raw")
 
     op.drop_index(
@@ -156,8 +153,6 @@ def downgrade() -> None:
 
     op.execute("DROP INDEX IF EXISTS brin_fee_preview_raw_captured_at")
     op.drop_index(
-        "idx_fee_preview_raw_asin",
-        table_name="fee_preview_raw",
-        if_exists=True,
+        "idx_fee_preview_raw_asin", table_name="fee_preview_raw", if_exists=True
     )
     op.drop_table("fee_preview_raw")

--- a/services/etl/dialects/amazon_fee_preview.py
+++ b/services/etl/dialects/amazon_fee_preview.py
@@ -11,7 +11,10 @@ SYNONYMS = {
     "sku": ["seller-sku", "sku"],
     "fnsku": ["fnsku"],
     "referral_fee": ["estimated-referral-fee-per-unit", "referral-fee-per-unit"],
-    "fulfillment_fee": ["estimated-fulfillment-fee-per-unit", "fulfillment-fee-per-unit"],
+    "fulfillment_fee": [
+        "estimated-fulfillment-fee-per-unit",
+        "fulfillment-fee-per-unit",
+    ],
     "storage_fee": ["estimated-storage-fee-per-unit", "storage-fee-per-unit"],
     "estimated_fee_total": [
         "estimated-fee-total",
@@ -50,7 +53,12 @@ def normalise(df: DataFrame) -> DataFrame:
         df["captured_at"] = pd.Timestamp.utcnow()
     for col in TARGET_COLUMNS:
         if col not in df.columns:
-            if col in {"referral_fee", "fulfillment_fee", "storage_fee", "estimated_fee_total"}:
+            if col in {
+                "referral_fee",
+                "fulfillment_fee",
+                "storage_fee",
+                "estimated_fee_total",
+            }:
                 df[col] = pd.Series([np.nan] * len(df), dtype="float64")
             else:
                 df[col] = pd.NA

--- a/services/etl/dialects/amazon_inventory_ledger.py
+++ b/services/etl/dialects/amazon_inventory_ledger.py
@@ -52,7 +52,6 @@ def detect(columns: list[str]) -> bool:
     has_date = any(opt in cols for opt in SYNONYMS["event_date"])
     has_type = any(opt in cols for opt in SYNONYMS["event_type"])
     has_id = any(
-        opt in cols
-        for opt in SYNONYMS["fnsku"] + SYNONYMS["sku"] + SYNONYMS["asin"]
+        opt in cols for opt in SYNONYMS["fnsku"] + SYNONYMS["sku"] + SYNONYMS["asin"]
     )
     return has_date and has_type and has_id

--- a/tests/etl/test_amazon_new_dialects.py
+++ b/tests/etl/test_amazon_new_dialects.py
@@ -13,11 +13,7 @@ from services.etl.dialects import (
 
 def test_fee_preview_detect_normalise_schema():
     df = pd.DataFrame(
-        {
-            "asin": ["A1"],
-            "estimated-fee-total": [1.23],
-            "currency": ["USD"],
-        }
+        {"asin": ["A1"], "estimated-fee-total": [1.23], "currency": ["USD"]}
     )
     assert amazon_fee_preview.detect(list(df.columns))
     df = amazon_fee_preview.normalise(df)

--- a/tests/etl/test_copy_loader.py
+++ b/tests/etl/test_copy_loader.py
@@ -8,13 +8,13 @@ import pandas as pd
 import pytest
 from sqlalchemy import create_engine, text
 
-from services.ingest.copy_loader import copy_df_via_temp
 from services.etl.dialects import (
     amazon_ads_sp_cost,
     amazon_fee_preview,
     amazon_inventory_ledger,
     amazon_settlements,
 )
+from services.ingest.copy_loader import copy_df_via_temp
 
 TEST_DSN = os.getenv("TEST_DATABASE_URL")
 
@@ -57,9 +57,7 @@ def engine():
                 """
             )
         )
-        conn.execute(
-            text("DROP TABLE IF EXISTS test_ingest.fee_preview_raw CASCADE")
-        )
+        conn.execute(text("DROP TABLE IF EXISTS test_ingest.fee_preview_raw CASCADE"))
         conn.execute(
             text(
                 """
@@ -296,11 +294,7 @@ def test_null_handling(engine):
 
 def test_fee_preview_append(engine):
     df = pd.DataFrame(
-        {
-            "asin": ["A1"],
-            "estimated_fee_total": [1.0],
-            "currency": ["USD"],
-        }
+        {"asin": ["A1"], "estimated_fee_total": [1.0], "currency": ["USD"]}
     )
     copy_df_via_temp(
         engine,


### PR DESCRIPTION
## Summary
- sort imports and reformat files so Ruff passes
- fix docker compose health check ps format

## Root Cause
- Ruff reported unsorted import blocks in `services/api/migrations/versions/0026_amazon_new_reports.py` and `tests/etl/test_copy_loader.py`, causing the unit job to fail
- The health-check job used `docker compose ps --format '{{.Name}} {{.State.Health.Status}}'`, which is invalid and produced a template parsing error

## Fix
- Reorder and format imports across affected files
- Update health-check step to use `docker compose ps --format '{{.Name}} {{.State}} {{.Health}}'`
- Reformat dialect and test modules for Ruff

## Repro Steps
- `ruff check .`
- `ruff format --check .`
- `pytest tests/etl/test_copy_loader.py -q --no-cov`
- `pytest tests/etl/test_amazon_new_dialects.py -q --no-cov`

## Risk
- Low: changes are import ordering, formatting, and CI script adjustment

## Links
- `ci-logs/latest/CI/0_unit.txt`
- `ci-logs/latest/test/1_health-checks.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a2519b2ce08333a0d0acb439793ae1