### PR TITLE
fix: add missing ASGI correlation ID dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 Jinja2==3.1.6
 alembic==1.13.1
 apscheduler==3.10.4  # async scheduler for freight cron
+asgi-correlation-id==4.3.1
 asyncpg==0.30.0
 black==25.1.0  # formatter used in CI step "black --check ."
 boto3


### PR DESCRIPTION
### Summary
- include `asgi-correlation-id` in development requirements so API modules import correctly

### Root Cause
- the CI unit tests failed to import `asgi_correlation_id` in `services/api/main.py` because the package was absent from `requirements-dev.txt`

### Fix
- add `asgi-correlation-id==4.3.1` to `requirements-dev.txt`

### Repro Steps
- `pip install -r requirements-dev.txt`
- `pytest -q --cov=services`

### Risk
- Low: adds a missing package pinned to a specific version used elsewhere in the project

### Links
- ci-logs/latest/CI/unit/12_Pytest.txt


------
https://chatgpt.com/codex/tasks/task_e_68a3021c53bc8333a4eea310e0fc00ec