### PR TITLE
Add structlog to development dependencies

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -31,6 +31,7 @@ respx==0.22.0
 ruff==0.4.4
 sentencepiece==0.2.0
 sqlalchemy==2.0.29
+structlog==24.1.0
 testcontainers==4.10.0
 types-requests==2.32.0.20240602
 uvicorn==0.35.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,6 +33,7 @@ requests==2.32.4
 respx==0.22.0
 ruff==0.4.4  # static linter used in CI step "ruff check ."
 sqlalchemy==2.0.29
+structlog==24.1.0
 testcontainers[postgres]==4.10.0
 types-requests==2.32.0.20240602
 docspec-python==2.2.2


### PR DESCRIPTION
## Summary
- add missing `structlog` dependency to dev and constraints lists

## Root cause
- tests import `services.api.errors` which uses `structlog`, but `requirements-dev.txt` lacked the package leading to `ModuleNotFoundError`

## Fix
- include `structlog==24.1.0` in `requirements-dev.txt`
- pin `structlog==24.1.0` in `constraints.txt`

## Repro steps
- `pip install -r requirements-dev.txt`
- `ruff check .`
- `ruff format --check .`
- `pytest -q --cov=services`

## Risk
- Low: adds a missing dependency used by API error handling

## Links
- `ci-logs/latest/CI/0_unit.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a319b687248333adebe1f4cdca11b2