### PR TITLE
api: add CORS middleware with env-driven allowlist and tests (PR#2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       ENABLE_LIVE: 0
       LLM_PROVIDER: stub
       ALEMBIC_CONFIG: /app/alembic.ini
+      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://web:3000}
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/api/tests/test_cors.py
+++ b/services/api/tests/test_cors.py
@@ -1,0 +1,76 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def _get_app(monkeypatch, **env):
+    env.setdefault("LLM_PROVIDER", "stub")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    import services.api.main as main
+
+    importlib.reload(main)
+
+    async def _noop() -> None:  # pragma: no cover
+        return None
+
+    monkeypatch.setattr(main, "_wait_for_db", _noop)
+
+    from services.api import db as api_db
+
+    class FakeSession:
+        async def execute(self, query):  # pragma: no cover - simple stub
+            class R:
+                def scalar(self):
+                    import datetime
+
+                    return datetime.datetime.utcnow()
+
+            return R()
+
+    async def fake_get_session():
+        yield FakeSession()
+
+    main.app.dependency_overrides[api_db.get_session] = fake_get_session
+    return main.app
+
+
+def test_cors_preflight_allowed(monkeypatch):
+    app = _get_app(
+        monkeypatch,
+        CORS_ORIGINS="http://localhost:3000,http://web:3000",
+    )
+    with TestClient(app) as client:
+        r = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert r.status_code in (200, 204)
+        assert r.headers.get("access-control-allow-origin") == "http://localhost:3000"
+        assert "access-control-allow-methods" in r.headers
+
+
+def test_cors_simple_get_allowed(monkeypatch):
+    app = _get_app(monkeypatch, CORS_ORIGINS="http://localhost:3000")
+    with TestClient(app) as client:
+        r = client.get("/health", headers={"Origin": "http://localhost:3000"})
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
+        assert r.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_cors_disallowed_origin(monkeypatch):
+    app = _get_app(monkeypatch, CORS_ORIGINS="http://localhost:3000")
+    with TestClient(app) as client:
+        r = client.options(
+            "/health",
+            headers={
+                "Origin": "http://evil.example",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert r.status_code in (200, 204, 400)
+        assert "access-control-allow-origin" not in r.headers


### PR DESCRIPTION
## Summary
- add optional CORS middleware configured via env vars
- cover allowed and disallowed origins with new tests
- wire default CORS_ORIGINS into docker-compose

## Root Cause
- API lacked CORS configuration, blocking browser clients that supply Origin headers from other hosts

## Fix
- add `CORSMiddleware` when `CORS_ORIGINS` or `CORS_ALLOW_ORIGIN_REGEX` is set
- parameterize credentials and origin regex via env vars
- exercise CORS behaviour in unit tests
- expose default `CORS_ORIGINS` in `docker-compose.yml`

## Repro Steps
- `python -m black services/api/main.py services/api/tests/test_cors.py`
- `ruff check services/api/main.py services/api/tests/test_cors.py`
- `PG_USER=postgres PG_PASSWORD=pass PG_DATABASE=awa PG_HOST=postgres PG_PORT=5432 LLM_PROVIDER=stub PYTHONPATH=. pytest services/api/tests/test_cors.py services/api/tests/test_health.py services/api/tests/test_errors_json.py services/api/tests/test_llm.py --no-cov`

## Risk
- Low: middleware is gated behind env vars and defaults to disabled.

## Links
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68a32759ebe88333a0f4c1c86d780188