### PR TITLE
Add Redis-backed global rate limiting with XFF-aware client id (PR#3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   unit:
     runs-on: ubuntu-latest
+    env:
+      REDIS_URL: redis://localhost:6379/0
+      RATE_LIMIT_DEFAULT: 100/minute
+      TRUST_X_FORWARDED: 1
     services:
       postgres:
         image: postgres:15
@@ -21,6 +25,9 @@ jobs:
         options: >-
           --health-cmd="pg_isready -U postgres -d awa"
           --health-interval=5s --health-timeout=5s --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
     steps:
       - uses: actions/checkout@v4
       - name: Load env
@@ -65,6 +72,10 @@ jobs:
   migrations-check:
     needs: unit
     runs-on: ubuntu-latest
+    env:
+      REDIS_URL: redis://localhost:6379/0
+      RATE_LIMIT_DEFAULT: 100/minute
+      TRUST_X_FORWARDED: 1
     services:
       postgres:
         image: postgres:15
@@ -76,6 +87,9 @@ jobs:
         options: >-
           --health-cmd="pg_isready -U postgres -d awa"
           --health-interval=5s --health-timeout=5s --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
     steps:
       - uses: actions/checkout@v4
       - name: Load env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      REDIS_URL: redis://localhost:6379/0
+      RATE_LIMIT_DEFAULT: 100/minute
+      TRUST_X_FORWARDED: 1
     services:
       postgres:
         image: postgres:15
@@ -24,6 +28,9 @@ jobs:
           --health-interval=5s
           --health-timeout=5s
           --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,9 @@ services:
       ENABLE_LIVE: 0
       LLM_PROVIDER: stub
       ALEMBIC_CONFIG: /app/alembic.ini
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      RATE_LIMIT_DEFAULT: ${RATE_LIMIT_DEFAULT:-100/minute}
+      TRUST_X_FORWARDED: ${TRUST_X_FORWARDED:-1}
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/api/errors.py
+++ b/services/api/errors.py
@@ -24,9 +24,14 @@ def install_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(StarletteHTTPException)
     async def _http_exception_handler(request: Request, exc: StarletteHTTPException):
-        structlog.get_logger().warning(
-            "http_error", status_code=exc.status_code, detail=str(exc.detail)
-        )
+        log = structlog.get_logger()
+        if exc.status_code == 429:
+            log.warning("rate_limited", detail=str(exc.detail))
+            return JSONResponse(
+                status_code=429,
+                content=_payload("rate_limited", "Too Many Requests", request),
+            )
+        log.warning("http_error", status_code=exc.status_code, detail=str(exc.detail))
         payload = _payload("http_error", str(exc.detail), request)
         return JSONResponse(status_code=exc.status_code, content=payload)
 

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -9,6 +9,7 @@ asyncpg==0.29.0
 boto3==1.34.162
 Jinja2==3.1.5
 celery==5.3.*
-redis==5.*
 structlog==24.1.0
 asgi-correlation-id==4.3.1
+fastapi-limiter==0.1.5
+redis==5.0.8

--- a/services/api/tests/test_rate_limit.py
+++ b/services/api/tests/test_rate_limit.py
@@ -1,0 +1,67 @@
+import os
+
+from fastapi.testclient import TestClient
+
+# Set env BEFORE importing app so the limiter initializes properly in this process.
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault(
+    "RATE_LIMIT_DEFAULT", "100/minute"
+)  # high enough to avoid interference
+os.environ.setdefault("TRUST_X_FORWARDED", "1")
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql+asyncpg://postgres:pass@localhost:5432/awa"
+)
+
+from services.api import db as api_db  # noqa: E402
+from services.api import main as api_main  # noqa: E402
+
+
+async def _noop() -> None:
+    pass
+
+
+api_main._wait_for_db = _noop
+app = api_main.app  # noqa: E402
+
+
+class FakeSession:
+    async def execute(self, query):
+        class R:
+            def scalar(self):
+                import datetime
+
+                return datetime.datetime.utcnow()
+
+        return R()
+
+
+async def fake_get_session():
+    yield FakeSession()
+
+
+def test_rate_limit_exceeded_returns_429():
+    # Use a unique client IP so we don't affect other tests.
+    headers = {"X-Forwarded-For": "203.0.113.77"}
+    with TestClient(app) as client:
+        app.dependency_overrides[api_db.get_session] = fake_get_session
+        try:
+            # exceed 100/min quickly (send >100 GETs)
+            codes = []
+            for _ in range(120):
+                r = client.get("/health", headers=headers)
+                codes.append(r.status_code)
+            counts = {code: codes.count(code) for code in set(codes)}
+            assert 429 in codes, f"No 429 observed, got counts: {counts}"
+        finally:
+            app.dependency_overrides.clear()
+
+
+def test_different_client_ip_has_independent_bucket():
+    with TestClient(app) as client:
+        app.dependency_overrides[api_db.get_session] = fake_get_session
+        try:
+            r1 = client.get("/health", headers={"X-Forwarded-For": "203.0.113.88"})
+            r2 = client.get("/health", headers={"X-Forwarded-For": "203.0.113.99"})
+            assert r1.status_code == 200 and r2.status_code == 200
+        finally:
+            app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add Redis-backed global rate limiting with optional X-Forwarded-For trust
- return standardized 429 JSON when requests exceed rate limits
- exercise rate limiter in tests and wire up Redis in CI and compose

## Testing
- `ruff check services/api/main.py services/api/errors.py services/api/tests/test_rate_limit.py`
- `ruff format --check services/api/main.py services/api/errors.py services/api/tests/test_rate_limit.py`
- `PYTEST_ADDOPTS="--cov-fail-under=0" PYTHONPATH=. pytest services/api/tests/test_rate_limit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a33d328a0483338f95d7d59d11e52e