### PR TITLE
Add fastapi-limiter dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ minio==7.*
 celery==5.4.0  # needed by fee-cron test import
 fastapi==0.116.1
 fastapi[all]
+fastapi-limiter==0.1.6
 httpx>=0.27,<0.29
 imapclient==3.0.1
 itsdangerous

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -11,5 +11,5 @@ Jinja2==3.1.5
 celery==5.3.*
 structlog==24.1.0
 asgi-correlation-id==4.3.1
-fastapi-limiter==0.1.5
+fastapi-limiter==0.1.6
 redis==5.0.8


### PR DESCRIPTION
## Summary
- include `fastapi-limiter` in dev dependencies so API tests can import rate limiter
- bump API service to `fastapi-limiter` 0.1.6, which supports Redis 5

## Root Cause
- CI failed because tests import `fastapi_limiter`, but the package wasn't installed and service requirements pinned `fastapi-limiter` 0.1.5 which conflicts with Redis 5【ci-logs/latest/CI/unit/12_Pytest.txt†L27-L39】【ci-logs/latest/test/1_test.txt†L688-L706】

## Fix
- add `fastapi-limiter==0.1.6` to `requirements-dev.txt`
- upgrade `services/api/requirements.txt` to `fastapi-limiter==0.1.6`

## Repro Steps
```bash
pip install -r requirements-dev.txt
pytest -q --cov=services  # requires running Redis and Postgres services
pip install -r services/api/requirements.txt
```

## Risk
- Low: dependency bump to latest compatible version

## Links
- `ci-logs/latest/CI/unit/12_Pytest.txt`
- `ci-logs/latest/test/1_test.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a3474c96f08333aea297ab11523489