### PR TITLE
Use context-managed TestClient

### DIFF
--- a/services/api/tests/test_errors_json.py
+++ b/services/api/tests/test_errors_json.py
@@ -16,17 +16,17 @@ def test_validation_error_json() -> None:
     os.environ["BASIC_USER"] = "u"
     os.environ["BASIC_PASS"] = "p"
     try:
-        client = TestClient(app)
-        auth = base64.b64encode(b"u:p").decode()
-        resp = client.get(
-            "/roi-review?vendor=abc", headers={"Authorization": f"Basic {auth}"}
-        )
-        assert resp.status_code == 422
-        data = resp.json()
-        assert data["error"]["type"] == "validation_error"
-        assert data["error"]["message"] == "Invalid request"
-        assert data["error"].get("request_id")
-        assert isinstance(data.get("details"), list)
+        with TestClient(app) as client:
+            auth = base64.b64encode(b"u:p").decode()
+            resp = client.get(
+                "/roi-review?vendor=abc", headers={"Authorization": f"Basic {auth}"}
+            )
+            assert resp.status_code == 422
+            data = resp.json()
+            assert data["error"]["type"] == "validation_error"
+            assert data["error"]["message"] == "Invalid request"
+            assert data["error"].get("request_id")
+            assert isinstance(data.get("details"), list)
     finally:
         if prev_user is None:
             os.environ.pop("BASIC_USER", None)
@@ -49,10 +49,10 @@ def test_db_error_json() -> None:
         yield BrokenSession()
 
     app.dependency_overrides[api_db.get_session] = fake_get_session
-    client = TestClient(app)
     try:
-        resp = client.get("/health")
-        assert resp.status_code == 500
-        assert resp.json()["error"]["type"] == "db_unavailable"
+        with TestClient(app) as client:
+            resp = client.get("/health")
+            assert resp.status_code == 500
+            assert resp.json()["error"]["type"] == "db_unavailable"
     finally:
         app.dependency_overrides.clear()

--- a/services/api/tests/test_health.py
+++ b/services/api/tests/test_health.py
@@ -19,8 +19,8 @@ def test_health_route() -> None:
         yield FakeSession()
 
     app.dependency_overrides[db.get_session] = fake_get_session
-    client = TestClient(app)
-    resp = client.get("/health")
-    assert resp.status_code == 200
-    assert resp.json() == {"status": "ok"}
+    with TestClient(app) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
     app.dependency_overrides.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,8 @@ def api_client(pg_pool):
 
     from services.api.main import app
 
-    return TestClient(app)  # type: ignore[arg-type]
+    with TestClient(app) as client:  # type: ignore[arg-type]
+        yield client
 
 
 @pytest.fixture

--- a/tests/test_api_fast.py
+++ b/tests/test_api_fast.py
@@ -21,8 +21,8 @@ async def fake_get_session():
 
 def test_health_endpoint(monkeypatch):
     app.dependency_overrides[db.get_session] = fake_get_session
-    client = TestClient(app)
-    r = client.get("/health")
-    assert r.status_code == 200
-    assert r.json() == {"status": "ok"}
+    with TestClient(app) as client:
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- ensure FastAPI startup events run in tests by using TestClient as a context manager

## Root Cause
- Tests instantiated `TestClient` without entering its context, so FastAPI's lifespan hooks never ran and `FastAPILimiter` remained uninitialized, causing rate limiter and event loop errors.

## Fix
- Wrap all relevant tests and fixtures in `with TestClient(...)` to trigger startup and shutdown events

## Repro Steps
- `pytest -q --cov=services`

## Risk
- Low: affects test code only; production logic untouched.

## Links
- ci-logs/latest/CI/unit/12_Pytest.txt


------
https://chatgpt.com/codex/tasks/task_e_68a362a20c488333a134bdd89f460b18