### PR TITLE
Fix migrations check FastAPILimiter init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,9 @@ jobs:
           python - <<'PY'
           from fastapi.testclient import TestClient
           from services.api.main import app
-          c = TestClient(app)
-          r = c.get('/roi-review')
-          assert r.status_code < 500, r.text
+          with TestClient(app) as c:
+              r = c.get('/roi-review')
+              assert r.status_code < 500, r.text
           PY
       - name: Alembic downgrade
         run: alembic -c services/api/alembic.ini downgrade base


### PR DESCRIPTION
## Summary
- ensure ROI smoke test triggers FastAPI startup

## Root Cause
- TestClient was instantiated without a context manager, so FastAPI lifespan hooks never ran and `FastAPILimiter` was not initialized

## Fix
- wrap ROI smoke test in a `with TestClient(app)` block

## Repro Steps
- `python - <<'PY'
from fastapi.testclient import TestClient
from services.api.main import app
with TestClient(app) as c:
    r = c.get('/roi-review')
assert r.status_code < 500, r.text
PY`

## Risk
- Low: change only affects CI smoke test code

## Links
- ci-logs/latest/CI/2_migrations-check.txt


------
https://chatgpt.com/codex/tasks/task_e_68a3752ecc648333b75ae09697a71ddd