### PR TITLE
obs: integrate self-hosted Sentry for API & Celery with PII scrubbing and tests (PR#4)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,11 @@ services:
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
       RATE_LIMIT_DEFAULT: ${RATE_LIMIT_DEFAULT:-100/minute}
       TRUST_X_FORWARDED: ${TRUST_X_FORWARDED:-1}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENV: ${SENTRY_ENV:-local}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.05}
+      SENTRY_PROFILES_SAMPLE_RATE: ${SENTRY_PROFILES_SAMPLE_RATE:-0.0}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -141,6 +146,11 @@ services:
       PG_PORT: 5432
       DATABASE_URL: postgresql+asyncpg://postgres:pass@postgres:5432/awa
       ENABLE_LIVE: 0
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENV: ${SENTRY_ENV:-local}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.05}
+      SENTRY_PROFILES_SAMPLE_RATE: ${SENTRY_PROFILES_SAMPLE_RATE:-0.0}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
     depends_on:
       redis:
         condition: service_started
@@ -166,6 +176,11 @@ services:
       SCHEDULE_NIGHTLY_MAINTENANCE: "true"
       NIGHTLY_MAINTENANCE_CRON: "30 2 * * *"
       TABLE_MAINTENANCE_LIST: "public.reimbursements_raw,public.returns_raw"
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENV: ${SENTRY_ENV:-local}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.05}
+      SENTRY_PROFILES_SAMPLE_RATE: ${SENTRY_PROFILES_SAMPLE_RATE:-0.0}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
     depends_on:
       redis:
         condition: service_started
@@ -229,6 +244,11 @@ services:
       PG_PORT: 5432
       DATABASE_URL: postgresql+asyncpg://postgres:pass@postgres:5432/awa
       PYTHONPATH: /app:/app/services
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENV: ${SENTRY_ENV:-local}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.05}
+      SENTRY_PROFILES_SAMPLE_RATE: ${SENTRY_PROFILES_SAMPLE_RATE:-0.0}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
     command: ["python", "-m", "fees_h10.worker"]
     depends_on:
       postgres:

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -19,6 +19,7 @@ from alembic.script import ScriptDirectory
 from api.routers.ingest import router as ingest_router
 from services.api.errors import install_exception_handlers
 from services.api.logging_config import configure_logging
+from services.api.sentry_config import init_sentry_if_configured
 from services.common.dsn import build_dsn
 from services.ingest.upload_router import router as upload_router
 
@@ -28,6 +29,7 @@ from .routes.roi import router as roi_router
 from .routes.stats import router as stats_router
 
 configure_logging()
+init_sentry_if_configured()
 
 
 def _is_truthy(v: str | None) -> bool:
@@ -59,11 +61,7 @@ def _parse_rate_limit(s: str) -> tuple[int, int]:
     seconds = (
         60
         if unit.startswith("min")
-        else 1
-        if unit.startswith("sec")
-        else 3600
-        if unit.startswith("hour")
-        else 60
+        else 1 if unit.startswith("sec") else 3600 if unit.startswith("hour") else 60
     )
     return max(times, 1), seconds
 

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -13,3 +13,4 @@ structlog==24.1.0
 asgi-correlation-id==4.3.1
 fastapi-limiter==0.1.6
 redis==5.0.8
+sentry-sdk[fastapi,celery,sqlalchemy]==2.9.0

--- a/services/api/sentry_config.py
+++ b/services/api/sentry_config.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+
+import sentry_sdk
+from asgi_correlation_id import correlation_id
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+_SCRUB_HEADERS = {"authorization", "cookie", "set-cookie", "x-api-key"}
+_SCRUB_FIELDS = {
+    "password",
+    "pass",
+    "pwd",
+    "email",
+    "phone",
+    "token",
+    "secret",
+    "api_key",
+    "apikey",
+    "authorization",
+}
+
+
+def _is_truthy(v: str | None) -> bool:
+    return (v or "").strip().lower() in {"1", "true", "yes", "y"}
+
+
+def _scrub_mapping(d: dict | None) -> dict | None:
+    if not isinstance(d, dict):
+        return d
+    red = {}
+    for k, v in d.items():
+        key = str(k).lower()
+        if key in _SCRUB_FIELDS or key in _SCRUB_HEADERS:
+            red[k] = "[redacted]"
+        elif isinstance(v, dict):
+            red[k] = _scrub_mapping(v)
+        elif isinstance(v, list):
+            red[k] = [
+                (
+                    "[redacted]"
+                    if isinstance(x, (str, bytes)) and key in _SCRUB_FIELDS
+                    else x
+                )
+                for x in v
+            ]
+        else:
+            red[k] = v
+    return red
+
+
+def before_send(event, hint):
+    # attach request_id tag
+    rid = correlation_id.get()
+    if rid:
+        event.setdefault("tags", {})["request_id"] = rid
+    # scrub request headers/body
+    req = event.get("request") or {}
+    headers = req.get("headers")
+    if isinstance(headers, dict):
+        req["headers"] = {
+            k: ("[redacted]" if str(k).lower() in _SCRUB_HEADERS else v)
+            for k, v in headers.items()
+        }
+    data = req.get("data")
+    if isinstance(data, dict):
+        req["data"] = _scrub_mapping(data)
+    event["request"] = req
+    # scrub extra/context/user
+    if "extra" in event and isinstance(event["extra"], dict):
+        event["extra"] = _scrub_mapping(event["extra"])
+    if "contexts" in event and isinstance(event["contexts"], dict):
+        event["contexts"] = _scrub_mapping(event["contexts"])
+    if "user" in event and isinstance(event["user"], dict):
+        event["user"] = _scrub_mapping(event["user"])
+    return event
+
+
+def init_sentry_if_configured():
+    dsn = os.getenv("SENTRY_DSN", "").strip()
+    if not dsn:
+        return  # disabled
+    env = os.getenv("SENTRY_ENV", "local")
+    release = os.getenv("SENTRY_RELEASE") or os.getenv("COMMIT_SHA")
+    traces_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.05"))
+    profiles_rate = float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.0"))
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=env,
+        release=release,
+        send_default_pii=False,
+        before_send=before_send,
+        integrations=[
+            FastApiIntegration(),
+            SqlalchemyIntegration(),
+            CeleryIntegration(),
+            LoggingIntegration(
+                level=None, event_level=None
+            ),  # breadcrumbs only; no log->event promotion
+        ],
+        traces_sample_rate=traces_rate,
+        profiles_sample_rate=profiles_rate,
+    )

--- a/services/api/tests/test_sentry_event.py
+++ b/services/api/tests/test_sentry_event.py
@@ -1,0 +1,55 @@
+import os
+
+import sentry_sdk
+from fastapi.testclient import TestClient
+
+# set env before importing app so init runs
+os.environ["SENTRY_DSN"] = "http://public@selfhosted.invalid/1"
+os.environ["SENTRY_ENV"] = "test"
+os.environ["SENTRY_TRACES_SAMPLE_RATE"] = "0.0"
+os.environ["SENTRY_PROFILES_SAMPLE_RATE"] = "0.0"
+
+from services.api.main import app  # noqa: E402
+
+
+class DummyTransport:
+    def __init__(self, options):
+        self.captured = []
+        self.parsed_dsn = None
+
+    def capture_event(self, event):
+        self.captured.append(event)
+
+    def flush(self, timeout=None, callback=None):  # pragma: no cover - test helper
+        if callback:
+            callback(None, True)
+
+    def capture_envelope(self, envelope):  # pragma: no cover - test helper
+        pass
+
+    def record_lost_event(self, *args, **kwargs):  # pragma: no cover - test helper
+        pass
+
+
+def test_unhandled_exception_is_captured_and_tagged(monkeypatch):
+    # install dummy transport
+    hub = sentry_sdk.Hub.current
+    if hub.client is not None:
+        hub.client.transport = DummyTransport(hub.client.options)
+
+    # inject a failing route
+    def boom():
+        raise RuntimeError("boom")
+
+    app.add_api_route("/__boom", boom, methods=["GET"])
+
+    with TestClient(app) as client:
+        r = client.get("/__boom", headers={"X-Request-ID": "test-rid-123"})
+        assert r.status_code == 500
+
+    # verify captured event with tag
+    tr = hub.client.transport
+    assert isinstance(tr, DummyTransport)
+    assert len(tr.captured) >= 1
+    event = tr.captured[-1]
+    assert event.get("tags", {}).get("request_id") == "test-rid-123"

--- a/services/api/tests/test_sentry_scrub.py
+++ b/services/api/tests/test_sentry_scrub.py
@@ -1,0 +1,27 @@
+from services.api.sentry_config import before_send
+
+
+def test_before_send_scrubs_pii():
+    event = {
+        "request": {
+            "headers": {
+                "Authorization": "Bearer SECRET",
+                "X-Other": "ok",
+                "Cookie": "a=b",
+            },
+            "data": {"password": "123", "email": "a@b.c", "keep": "ok"},
+        },
+        "user": {"email": "user@example.com", "id": "42"},
+        "extra": {"token": "XYZ", "keep": "ok"},
+    }
+    red = before_send(event, hint=None)
+    req = red["request"]
+    assert req["headers"]["Authorization"] == "[redacted]"
+    assert req["headers"]["Cookie"] == "[redacted]"
+    assert req["headers"]["X-Other"] == "ok"
+    assert req["data"]["password"] == "[redacted]"
+    assert req["data"]["email"] == "[redacted]"
+    assert req["data"]["keep"] == "ok"
+    assert red["user"]["email"] == "[redacted]"
+    assert red["extra"]["token"] == "[redacted]"
+    assert red["extra"]["keep"] == "ok"

--- a/services/fees_h10/worker.py
+++ b/services/fees_h10/worker.py
@@ -4,8 +4,12 @@ import os
 from celery import Celery, shared_task
 from sqlalchemy import create_engine, text
 
+from services.api.sentry_config import init_sentry_if_configured as _init_sentry
+
 from .client import fetch_fees
 from .repository import upsert
+
+_init_sentry()
 
 
 def list_active_asins() -> list[str]:

--- a/services/ingest/celery_app.py
+++ b/services/ingest/celery_app.py
@@ -6,6 +6,10 @@ import os
 from celery import Celery
 from celery.schedules import crontab
 
+from services.api.sentry_config import init_sentry_if_configured as _init_sentry
+
+_init_sentry()
+
 
 def make_celery() -> Celery:
     broker = os.getenv("CELERY_BROKER_URL", "redis://redis:6379/0")


### PR DESCRIPTION
## Summary
- integrate Sentry SDK for FastAPI, SQLAlchemy, and Celery with env-based config and request ID tagging
- scrub sensitive headers and fields before events are sent
- initialize Sentry in API and Celery workers and add tests covering event capture and PII sanitization

## Testing
- `ruff check services/api/sentry_config.py services/api/main.py services/ingest/celery_app.py services/fees_h10/worker.py services/api/tests/test_sentry_event.py services/api/tests/test_sentry_scrub.py` (passed)
- `black services/api/sentry_config.py services/api/main.py services/ingest/celery_app.py services/fees_h10/worker.py services/api/tests/test_sentry_event.py services/api/tests/test_sentry_scrub.py` (passed)
- `pytest -q` *(failed: Database not available / Redis connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68a37d2f4eac8333af840887078ea29d