### PR TITLE
Fix Sentry test transport and format API main module

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -61,7 +61,11 @@ def _parse_rate_limit(s: str) -> tuple[int, int]:
     seconds = (
         60
         if unit.startswith("min")
-        else 1 if unit.startswith("sec") else 3600 if unit.startswith("hour") else 60
+        else 1
+        if unit.startswith("sec")
+        else 3600
+        if unit.startswith("hour")
+        else 60
     )
     return max(times, 1), seconds
 

--- a/services/api/tests/test_sentry_event.py
+++ b/services/api/tests/test_sentry_event.py
@@ -22,12 +22,16 @@ class DummyTransport:
 
     def flush(self, timeout=None, callback=None):  # pragma: no cover - test helper
         if callback:
-            callback(None, True)
+            callback(0, True)
+        return 0
 
     def capture_envelope(self, envelope):  # pragma: no cover - test helper
         pass
 
     def record_lost_event(self, *args, **kwargs):  # pragma: no cover - test helper
+        pass
+
+    def kill(self):  # pragma: no cover - test helper
         pass
 
 


### PR DESCRIPTION
### Summary
- format `services/api/main.py` to satisfy ruff formatting
- ensure Sentry DummyTransport reports zero pending events and supports shutdown

### Root Cause
- `ruff format --check` failed because `services/api/main.py` was not formatted
- test `test_unhandled_exception_is_captured_and_tagged` crashed when Sentry's atexit integration tried to format a `None` pending count from `DummyTransport.flush`

### Fix
- run `ruff format` on `services/api/main.py`
- update `DummyTransport.flush` to call the callback with `0` pending events and return `0`
- add a no-op `kill` method to `DummyTransport`

### Repro Steps
1. `ruff check .`
2. `ruff format --check .`
3. `pytest services/api/tests/test_sentry_event.py::test_unhandled_exception_is_captured_and_tagged` *(requires database & redis services running)*

### Risk
- Low: changes touch only formatting and test helper code

### Links
- `ci-logs/latest/CI/unit/7_Check code formatting.txt`
- `ci-logs/latest/test/2_test.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a3833a581883339f0fe8c7f17c78bc