### PR TITLE
fix failing Sentry event test

### DIFF
--- a/services/api/tests/test_sentry_event.py
+++ b/services/api/tests/test_sentry_event.py
@@ -47,7 +47,7 @@ def test_unhandled_exception_is_captured_and_tagged(monkeypatch):
 
     app.add_api_route("/__boom", boom, methods=["GET"])
 
-    with TestClient(app) as client:
+    with TestClient(app, raise_server_exceptions=False) as client:
         r = client.get("/__boom", headers={"X-Request-ID": "test-rid-123"})
         assert r.status_code == 500
 


### PR DESCRIPTION
## Summary
- ensure Sentry event test doesn't raise server exceptions

## Root Cause
- `services/api/tests/test_sentry_event.py` used `TestClient` without disabling `raise_server_exceptions`, causing `RuntimeError` to propagate instead of returning a 500 response

## Fix
- invoke `TestClient(app, raise_server_exceptions=False)`

## Repro Steps
- `pytest services/api/tests/test_sentry_event.py::test_unhandled_exception_is_captured_and_tagged -q`

## Risk
- Low: only affects test configuration

## Links
- ci-logs/latest/CI/0_unit.txt


------
https://chatgpt.com/codex/tasks/task_e_68a387439368833381c5afcce3c4a999