### PR TITLE
Ensure unhandled API exceptions reach Sentry

### DIFF
--- a/services/api/errors.py
+++ b/services/api/errors.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import psycopg
+import sentry_sdk
 import structlog
 from asgi_correlation_id import correlation_id
 from fastapi import FastAPI, Request
@@ -54,5 +55,6 @@ def install_exception_handlers(app: FastAPI) -> None:
         request: Request, exc: Exception
     ) -> JSONResponse:
         structlog.get_logger().exception("unhandled_error")
+        sentry_sdk.capture_exception(exc)
         payload = _payload("internal_error", "Internal server error", request)
         return JSONResponse(status_code=500, content=payload)


### PR DESCRIPTION
## Summary
- capture unhandled API exceptions in Sentry so error events are logged

## Root Cause
- `services/api/errors.py` defines a catch-all exception handler that returned a JSON error but never reported the exception to Sentry, leaving `DummyTransport.captured` empty in tests.

## Fix
- import `sentry_sdk`
- call `sentry_sdk.capture_exception` within the unhandled exception handler

## Repro Steps
- `pytest services/api/tests/test_sentry_event.py::test_unhandled_exception_is_captured_and_tagged -q` *(fails without fix)*
- `python -m ruff check services/api/errors.py`

## Risk
- Low: new Sentry capture call may increase error reporting volume, but only for previously unreported exceptions.

## Links
- ci-logs/latest/CI/0_unit.txt


------
https://chatgpt.com/codex/tasks/task_e_68a38baf389c8333ad6a6608cc508c38