### PR TITLE
Fix Sentry test and add typing

### DIFF
--- a/services/api/sentry_config.py
+++ b/services/api/sentry_config.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import os
+from typing import Any, Dict, Mapping
+
+from sentry_sdk.types import Event, Hint
 
 import sentry_sdk
 from asgi_correlation_id import correlation_id
@@ -9,8 +12,8 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
-_SCRUB_HEADERS = {"authorization", "cookie", "set-cookie", "x-api-key"}
-_SCRUB_FIELDS = {
+_SCRUB_HEADERS: set[str] = {"authorization", "cookie", "set-cookie", "x-api-key"}
+_SCRUB_FIELDS: set[str] = {
     "password",
     "pass",
     "pwd",
@@ -28,22 +31,18 @@ def _is_truthy(v: str | None) -> bool:
     return (v or "").strip().lower() in {"1", "true", "yes", "y"}
 
 
-def _scrub_mapping(d: dict | None) -> dict | None:
-    if not isinstance(d, dict):
-        return d
-    red = {}
+def _scrub_mapping(d: Mapping[str, Any]) -> Dict[str, Any]:
+    red: Dict[str, Any] = {}
     for k, v in d.items():
         key = str(k).lower()
         if key in _SCRUB_FIELDS or key in _SCRUB_HEADERS:
             red[k] = "[redacted]"
-        elif isinstance(v, dict):
+        elif isinstance(v, Mapping):
             red[k] = _scrub_mapping(v)
         elif isinstance(v, list):
             red[k] = [
                 (
-                    "[redacted]"
-                    if isinstance(x, (str, bytes)) and key in _SCRUB_FIELDS
-                    else x
+                    "[redacted]" if isinstance(x, (str, bytes)) and key in _SCRUB_FIELDS else x
                 )
                 for x in v
             ]
@@ -52,34 +51,34 @@ def _scrub_mapping(d: dict | None) -> dict | None:
     return red
 
 
-def before_send(event, hint):
+def before_send(event: Event, hint: Hint) -> Event | None:
     # attach request_id tag
     rid = correlation_id.get()
     if rid:
         event.setdefault("tags", {})["request_id"] = rid
     # scrub request headers/body
-    req = event.get("request") or {}
+    req: Dict[str, Any] = event.get("request") or {}
     headers = req.get("headers")
-    if isinstance(headers, dict):
+    if isinstance(headers, Mapping):
         req["headers"] = {
             k: ("[redacted]" if str(k).lower() in _SCRUB_HEADERS else v)
             for k, v in headers.items()
         }
     data = req.get("data")
-    if isinstance(data, dict):
+    if isinstance(data, Mapping):
         req["data"] = _scrub_mapping(data)
     event["request"] = req
     # scrub extra/context/user
-    if "extra" in event and isinstance(event["extra"], dict):
+    if "extra" in event and isinstance(event["extra"], Mapping):
         event["extra"] = _scrub_mapping(event["extra"])
-    if "contexts" in event and isinstance(event["contexts"], dict):
+    if "contexts" in event and isinstance(event["contexts"], Mapping):
         event["contexts"] = _scrub_mapping(event["contexts"])
-    if "user" in event and isinstance(event["user"], dict):
+    if "user" in event and isinstance(event["user"], Mapping):
         event["user"] = _scrub_mapping(event["user"])
     return event
 
 
-def init_sentry_if_configured():
+def init_sentry_if_configured() -> None:
     dsn = os.getenv("SENTRY_DSN", "").strip()
     if not dsn:
         return  # disabled

--- a/services/api/tests/test_sentry_event.py
+++ b/services/api/tests/test_sentry_event.py
@@ -26,7 +26,13 @@ class DummyTransport:
         return 0
 
     def capture_envelope(self, envelope):  # pragma: no cover - test helper
-        pass
+        """Capture events sent as envelopes by Sentry SDK >= 2.0."""
+        try:
+            event = envelope.get_event()
+        except Exception:  # pragma: no cover - defensive
+            event = None
+        if event is not None:
+            self.captured.append(event)
 
     def record_lost_event(self, *args, **kwargs):  # pragma: no cover - test helper
         pass


### PR DESCRIPTION
### Summary
- handle Sentry SDK v2 envelopes in test transport
- add typing to `sentry_config` for mypy

### Root cause
- The Sentry test used a dummy transport that only implemented `capture_event`, so no envelope-based events were recorded and the assertion failed.
- `sentry_config.py` lacked type hints, triggering mypy errors.

### Fix
- Capture events from envelopes in `DummyTransport`.
- Annotate Sentry helpers with proper types and mappings.

### Repro steps
- `python -m mypy services/api/sentry_config.py`
- `pytest services/api/tests/test_sentry_event.py -k unhandled_exception_is_captured_and_tagged`

### Risk
- Low: changes are limited to Sentry setup and tests.

### Links
- ci-logs/latest/test/2_test.txt


------
https://chatgpt.com/codex/tasks/task_e_68a38f9e8f548333b2197664cbfbfb30