### PR TITLE
Ensure fees service waits for Redis and tidy Sentry test imports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,6 +254,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - awa-net
     extra_hosts:

--- a/services/api/tests/test_sentry_event.py
+++ b/services/api/tests/test_sentry_event.py
@@ -1,8 +1,8 @@
 import os
+import uuid
 
 import sentry_sdk
 from fastapi.testclient import TestClient
-import uuid
 
 # set env before importing app so init runs
 os.environ["SENTRY_DSN"] = "http://public@selfhosted.invalid/1"


### PR DESCRIPTION
## Summary
- sort Sentry test imports to satisfy ruff
- wait for Redis before starting the fees_h10 service

## Root Cause
- `services/api/tests/test_sentry_event.py` had unsorted imports causing ruff to fail in CI.
- The `fees_h10` container started before Redis was ready, exiting with code 2.

## Fix
- Reordered imports in `services/api/tests/test_sentry_event.py`.
- Added a Redis dependency to `fees_h10` in `docker-compose.yml` to ensure the broker is healthy before the service starts.

## Repro Steps
1. `ruff check .`
2. `ruff format --check .`
3. `pytest tests/test_fees_h10.py -q --override-ini="addopts="`

## Risk
- Low: import sorting and docker-compose dependency only affect test linting and service startup sequencing.

## Links
- `ci-logs/latest/CI/0_unit.txt`
- `ci-logs/latest/test/2_health-checks.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1af0ab48333b5d1ead5688c6be6