### PR TITLE
Add Redis healthcheck for compose stability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,12 @@ services:
     restart: unless-stopped
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      start_period: 30s
+      interval: 10s
+      timeout: 3s
+      retries: 5
     networks:
       - awa-net
   imap_watcher:


### PR DESCRIPTION
### Summary
- ensure docker-compose includes a healthcheck for the Redis service

### Root Cause
- CI and test workflows failed because `docker compose up --wait` requires all services to define healthchecks, and the Redis container lacked one, causing startup to abort

### Fix
- add a `redis-cli ping` healthcheck to the `redis` service in `docker-compose.yml`

### Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait`

### Risk
- The new healthcheck pings Redis; minimal risk as the command is standard and only affects container readiness checks.

### Links
- ci-logs/latest/CI/3_compose-health.txt
- ci-logs/latest/test/2_health-checks.txt


------
https://chatgpt.com/codex/tasks/task_e_68a3a61322988333833c8e39ade5ac7c