### PR TITLE
Fix ruff formatting in fees_h10 worker

### DIFF
--- a/services/fees_h10/worker.py
+++ b/services/fees_h10/worker.py
@@ -10,9 +10,11 @@ try:
     # fall back to a no-op in slim containers.
     from services.api.sentry_config import init_sentry_if_configured as _init_sentry
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
+
     def _init_sentry() -> None:  # type: ignore[return-value]
         """Initialize Sentry when the shared config is unavailable."""
         return None
+
 
 from .client import fetch_fees
 from .repository import upsert


### PR DESCRIPTION
## Summary
- ensure fees_h10 worker complies with ruff formatting

## Root Cause
- `services/fees_h10/worker.py` lacked blank line separators around the optional Sentry stub, causing `ruff format --check .` to fail

## Fix
- insert required blank lines and reformat `services/fees_h10/worker.py`

## Repro Steps
- `ruff check services/fees_h10/worker.py`
- `ruff format --check services/fees_h10/worker.py`
- `pytest services/fees_h10/tests/test_smoke.py -q -o addopts=`

## Risk
- Low: code behavior unchanged; only formatting adjustments

## Links
- `ci-logs/latest/CI/unit/7_Check code formatting.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a3b81162308333ac8d58173b503b60