### PR TITLE
fix: sort imports and cover db_url utility

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-pytest_plugins = [
-    "tests.helpers.factories",
-]
+pytest_plugins = ["tests.helpers.factories"]

--- a/tests/helpers/factories.py
+++ b/tests/helpers/factories.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
-from pathlib import Path
-from typing import Iterable, Mapping, Sequence, Callable
+
 import csv
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, Sequence
+
 import pandas as pd
 import pytest
+
 
 @pytest.fixture
 def csv_file_factory(tmp_path: Path) -> Callable[..., Path]:
@@ -18,6 +21,7 @@ def csv_file_factory(tmp_path: Path) -> Callable[..., Path]:
           name="sample.csv",
       )
     """
+
     def _make_csv(
         *,
         headers: Sequence[str],
@@ -33,13 +37,16 @@ def csv_file_factory(tmp_path: Path) -> Callable[..., Path]:
             for r in rows:
                 writer.writerow({k: r.get(k, "") for k in headers})
         return p
+
     return _make_csv
+
 
 @pytest.fixture
 def xlsx_file_factory(tmp_path: Path) -> Callable[..., Path]:
     """
     Create an Excel file with the provided headers and rows.
     """
+
     def _make_xlsx(
         *,
         headers: Sequence[str],
@@ -50,7 +57,9 @@ def xlsx_file_factory(tmp_path: Path) -> Callable[..., Path]:
         df = pd.DataFrame(list(rows), columns=list(headers))
         df.to_excel(p, index=False)
         return p
+
     return _make_xlsx
+
 
 @pytest.fixture
 def large_csv_factory(csv_file_factory) -> Callable[..., Path]:
@@ -58,6 +67,7 @@ def large_csv_factory(csv_file_factory) -> Callable[..., Path]:
     Quickly generate a large CSV for performance/dedup tests.
     Fields: ASIN, qty, price
     """
+
     def _make_large_csv(
         n: int,
         *,
@@ -77,4 +87,5 @@ def large_csv_factory(csv_file_factory) -> Callable[..., Path]:
             encoding=encoding,
             name=name,
         )
+
     return _make_large_csv

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -1,0 +1,19 @@
+from services.common.db_url import build_url
+
+
+def test_build_url_from_parts(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("PG_USER", "u")
+    monkeypatch.setenv("PG_PASSWORD", "p")
+    monkeypatch.setenv("PG_HOST", "h")
+    monkeypatch.setenv("PG_PORT", "1")
+    monkeypatch.setenv("PG_DATABASE", "d")
+    assert build_url() == "postgresql+asyncpg://u:p@h:1/d"
+    assert build_url(async_=False) == "postgresql://u:p@h:1/d"
+
+
+def test_build_url_toggles_database_url(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:1/d")
+    assert build_url() == "postgresql+asyncpg://u:p@h:1/d"
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@h:1/d")
+    assert build_url(async_=False) == "postgresql://u:p@h:1/d"


### PR DESCRIPTION
## Summary
- sort test helper imports to satisfy ruff
- add tests for `build_url` in `services.common.db_url`

## Root Cause
- CI failed on ruff due to unsorted imports in `tests/helpers/factories.py`.
- Test workflow failed because overall coverage was below the 65% threshold and `services/common/db_url.py` had almost no tests.

## Fix
- Reordered imports in `tests/helpers/factories.py`.
- Added focused tests exercising `build_url` to raise coverage.

## Repro Steps
- `ruff check .`
- `ruff format --check .`
- `pytest -q` *(requires Postgres & Redis services; otherwise first test fails waiting for DB)*

## Risk
- Low: changes touch only test code and import ordering.

## Links
- `ci-logs/latest/CI/unit/7_Check code formatting.txt`
- `ci-logs/latest/test/1_test.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a43936a55883338af64cefe3f7edf3