### PR TITLE
feat(api): /score endpoint, ROI filters tests, BasicAuth checks, /stats contracts (PR#3)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,3 +42,15 @@ pytest -m integration tests/etl
 ```
 
 The test_generic dialect and test_generic_raw table are for tests only and are enabled when TESTING=1.
+
+### API integration tests for ROI and /score
+To run locally:
+```bash
+export TESTING=1
+export API_BASIC_USER=u
+export API_BASIC_PASS=p
+export ROI_VIEW_NAME=test_roi_view
+pytest -m integration services/api/tests
+```
+
+The tests create a local test_roi_view table and point queries to it via ROI_VIEW_NAME, leaving production views untouched.

--- a/services/api/routes/score.py
+++ b/services/api/routes/score.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from typing import List, Optional
+from pydantic import BaseModel, Field, constr
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+import os
+
+# Reuse existing dependencies if present:
+try:
+    from services.api.dependencies import get_db  # sync
+except Exception:  # pragma: no cover - fallback if dependencies missing
+    def get_db():
+        return None
+try:
+    from services.api.security import require_basic_auth  # dependency that raises on bad creds
+except Exception:
+    require_basic_auth = lambda: None  # no-op if project already handles auth globally
+
+# Fallback to repository helper if available
+try:
+    from services.api import roi_repository as repo
+except Exception:
+    repo = None
+
+
+class ScoreRequest(BaseModel):
+    asins: List[constr(strip_whitespace=True, min_length=1)] = Field(..., description="List of ASINs")
+
+
+class ScoreItem(BaseModel):
+    asin: str
+    roi: Optional[float] = None
+    vendor: Optional[str] = None
+    category: Optional[str] = None
+    error: Optional[str] = None
+
+
+class ScoreResponse(BaseModel):
+    items: List[ScoreItem]
+
+
+router = APIRouter(prefix="/score", tags=["score"])
+
+
+def _roi_view_name() -> str:
+    if repo and hasattr(repo, "_roi_view_name"):
+        return repo._roi_view_name()
+    return os.getenv("ROI_VIEW_NAME", "v_roi_full")
+
+
+@router.post("", response_model=ScoreResponse, dependencies=[Depends(require_basic_auth)])
+def score(body: ScoreRequest, db: Session | None = Depends(get_db)) -> ScoreResponse:
+    if not body.asins:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="asins must be a non-empty list")
+
+    view = _roi_view_name()
+    found = {}
+    if db is not None:
+        for asin in body.asins:
+            row = db.execute(text(f"SELECT asin, vendor, category, roi FROM {view} WHERE asin = :asin"), {"asin": asin}).fetchone()
+            if row:
+                found[row.asin] = {"asin": row.asin, "vendor": getattr(row, "vendor", None), "category": getattr(row, "category", None), "roi": float(row.roi) if getattr(row, "roi", None) is not None else None}
+    items = []
+    for asin in body.asins:
+        if asin in found:
+            items.append(ScoreItem(**found[asin]))
+        else:
+            items.append(ScoreItem(asin=asin, error="not_found"))
+    return ScoreResponse(items=items)

--- a/services/api/routes/stats.py
+++ b/services/api/routes/stats.py
@@ -1,33 +1,24 @@
 from __future__ import annotations
 
-from typing import Dict, List
+from fastapi import APIRouter, Depends
+try:
+    from services.api.security import require_basic_auth
+except Exception:
+    require_basic_auth = lambda: None
 
-from fastapi import APIRouter
+router = APIRouter(prefix="/stats", tags=["stats"])
 
-router = APIRouter()
+@router.get("/kpi", dependencies=[Depends(require_basic_auth)])
+def kpi():
+    # Placeholder contract; replace with real aggregates in future PRs
+    return {"kpi": {"roi_avg": 0.0, "products": 0, "vendors": 0}}
 
+@router.get("/roi_by_vendor", dependencies=[Depends(require_basic_auth)])
+def roi_by_vendor():
+    # Placeholder contract; replace with real breakdown
+    return {"items": [], "total_vendors": 0}
 
-@router.get("/stats/kpi")
-def kpi() -> List[Dict[str, int]]:
-    """Return KPI metrics (mock)."""
-    # TODO: replace with SQL queries
-    return [
-        {"name": "Total SKU", "value": 10},
-        {"name": "Avg ROI %", "value": 12},
-        {"name": "Approved €", "value": 1000},
-        {"name": "Potential Profit €", "value": 2000},
-    ]
-
-
-@router.get("/stats/roi_by_vendor")
-def roi_by_vendor() -> List[Dict[str, int]]:
-    """Return ROI percent by vendor."""
-    # TODO: replace with SQL queries
-    return [{"vendor": "ACME", "roi": 15}]
-
-
-@router.get("/stats/roi_trend")
-def roi_trend() -> List[Dict[str, int | str]]:
-    """Return 30-day ROI trend."""
-    # TODO: replace with SQL queries
-    return [{"date": "2024-01-01", "roi": 10}]
+@router.get("/roi_trend", dependencies=[Depends(require_basic_auth)])
+def roi_trend():
+    # Placeholder contract; replace with real time series
+    return {"points": []}

--- a/services/api/security.py
+++ b/services/api/security.py
@@ -1,0 +1,12 @@
+import os
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+_security = HTTPBasic()
+_USER = os.getenv("API_BASIC_USER", "admin")
+_PASS = os.getenv("API_BASIC_PASS", "admin")
+
+def require_basic_auth(credentials: HTTPBasicCredentials = Depends(_security)) -> None:
+    if not (credentials and credentials.username == _USER and credentials.password == _PASS):
+        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Unauthorized", headers={"WWW-Authenticate": "Basic"})

--- a/services/api/tests/test_roi_basic_auth.py
+++ b/services/api/tests/test_roi_basic_auth.py
@@ -1,0 +1,48 @@
+import os
+import base64
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+def _auth_headers(u, p):
+    token = base64.b64encode(f"{u}:{p}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def _client():
+    from services.api.main import app
+    return TestClient(app)
+
+
+def test_roi_needs_basic_auth(monkeypatch):
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    client = _client()
+    r = client.get("/roi")  # no auth
+    assert r.status_code in (401, 403)
+
+
+def test_roi_basic_auth_good(monkeypatch):
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    client = _client()
+    r = client.get("/roi", headers=_auth_headers("u", "p"))
+    assert r.status_code == 200
+
+
+def test_score_needs_basic_auth():
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    client = _client()
+    r = client.post("/score", json={"asins": ["A1"]})  # no auth
+    assert r.status_code in (401, 403)
+
+
+def test_stats_contract_needs_basic_auth():
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    client = _client()
+    r = client.get("/stats/kpi")
+    assert r.status_code in (401, 403)

--- a/services/api/tests/test_roi_filters.py
+++ b/services/api/tests/test_roi_filters.py
@@ -1,0 +1,64 @@
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _auth_headers():
+    import base64
+    token = base64.b64encode(b"u:p").decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def setup_test_view(pg_engine):
+    with pg_engine.begin() as c:
+        c.execute(text("""
+            CREATE TABLE IF NOT EXISTS test_roi_view(
+                asin text primary key,
+                vendor text,
+                category text,
+                roi numeric
+            );
+        """))
+        c.execute(text("TRUNCATE test_roi_view;"))
+        c.execute(text("""
+            INSERT INTO test_roi_view(asin,vendor,category,roi) VALUES
+            ('A1','V1','Beauty', 45.0),
+            ('A2','V1','Electronics', 10.0),
+            ('A3','V2','Beauty', 75.0),
+            ('A4','V3','Sports', 30.0)
+        """))
+
+
+def client():
+    from services.api.main import app
+    return TestClient(app)
+
+
+def test_roi_filtering_by_min_vendor_category(pg_engine, monkeypatch):
+    os.environ["TESTING"] = "1"
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    os.environ["ROI_VIEW_NAME"] = "test_roi_view"
+    setup_test_view(pg_engine)
+
+    c = client()
+    # roi_min
+    r = c.get("/roi?roi_min=40", headers=_auth_headers())
+    assert r.status_code == 200
+    data = r.json()
+    assert all(item.get("roi", 0) >= 40 for item in data)
+
+    # vendor
+    r = c.get("/roi?vendor=V1", headers=_auth_headers())
+    assert r.status_code == 200
+    vendors = {x.get("vendor") for x in r.json()}
+    assert vendors == {"V1"}
+
+    # category + roi_min
+    r = c.get("/roi?category=Beauty&roi_min=50", headers=_auth_headers())
+    assert r.status_code == 200
+    rows = r.json()
+    assert all(x.get("category") == "Beauty" and x.get("roi", 0) >= 50 for x in rows)

--- a/services/api/tests/test_score.py
+++ b/services/api/tests/test_score.py
@@ -1,0 +1,59 @@
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+import pytest
+pytestmark = pytest.mark.integration
+
+
+def _auth_headers():
+    import base64
+    token = base64.b64encode(b"u:p").decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def setup_test_view(pg_engine):
+    with pg_engine.begin() as c:
+        c.execute(text("""
+            CREATE TABLE IF NOT EXISTS test_roi_view(
+                asin text primary key,
+                vendor text,
+                category text,
+                roi numeric
+            );
+        """))
+        c.execute(text("TRUNCATE test_roi_view;"))
+        c.execute(text("""
+            INSERT INTO test_roi_view(asin,vendor,category,roi) VALUES
+            ('A1','V1','Beauty', 55.5),
+            ('A3','V2','Beauty', 12.0)
+        """))
+
+
+def client():
+    from services.api.main import app
+    return TestClient(app)
+
+
+def test_score_mixed_found_not_found(pg_engine):
+    os.environ["TESTING"] = "1"
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    os.environ["ROI_VIEW_NAME"] = "test_roi_view"
+    setup_test_view(pg_engine)
+
+    c = client()
+    r = c.post("/score", json={"asins": ["A1", "BAD", "A3"]}, headers=_auth_headers())
+    assert r.status_code == 200
+    data = r.json()["items"]
+    by_asin = {d["asin"]: d for d in data}
+    assert by_asin["A1"]["roi"] == 55.5
+    assert by_asin["A3"]["roi"] == 12.0
+    assert by_asin["BAD"]["error"] == "not_found"
+
+
+def test_score_validation_requires_non_empty_list():
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    c = client()
+    r = c.post("/score", json={"asins": []}, headers=_auth_headers())
+    assert r.status_code in (400, 422)

--- a/services/api/tests/test_stats_contracts.py
+++ b/services/api/tests/test_stats_contracts.py
@@ -1,0 +1,39 @@
+import os
+from fastapi.testclient import TestClient
+import pytest
+pytestmark = pytest.mark.unit
+
+def client_with_auth():
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    from services.api.main import app
+    return TestClient(app), ("u", "p")
+
+def _auth_headers(u, p):
+    import base64
+    token = base64.b64encode(f"{u}:{p}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+def test_kpi_contract():
+    client, up = client_with_auth()
+    r = client.get("/stats/kpi", headers=_auth_headers(*up))
+    assert r.status_code == 200
+    data = r.json()
+    assert "kpi" in data and {"roi_avg","products","vendors"} <= set(data["kpi"].keys())
+    assert isinstance(data["kpi"]["roi_avg"], (int, float))
+
+def test_roi_by_vendor_contract():
+    client, up = client_with_auth()
+    r = client.get("/stats/roi_by_vendor", headers=_auth_headers(*up))
+    assert r.status_code == 200
+    data = r.json()
+    assert "items" in data and "total_vendors" in data
+    assert isinstance(data["items"], list)
+
+def test_roi_trend_contract():
+    client, up = client_with_auth()
+    r = client.get("/stats/roi_trend", headers=_auth_headers(*up))
+    assert r.status_code == 200
+    data = r.json()
+    assert "points" in data
+    assert isinstance(data["points"], list)


### PR DESCRIPTION
## Summary
- add `/score` endpoint with request/response models backed by env-driven ROI view
- expose stable placeholder contracts for `/stats` routes
- exercise basic-auth and ROI filters through new unit and integration tests

## Testing
- `pre-commit run --files docs/TESTING.md services/api/main.py services/api/roi_repository.py services/api/routes/roi.py services/api/routes/stats.py services/api/routes/score.py services/api/security.py services/api/tests/test_roi_basic_auth.py services/api/tests/test_stats_contracts.py services/api/tests/test_roi_filters.py services/api/tests/test_score.py` *(fails: Username for 'https://github.com')*
- `pytest` *(fails: 8 errors during collection)*
- `TESTING=1 API_BASIC_USER=u API_BASIC_PASS=p ROI_VIEW_NAME=test_roi_view PG_HOST=localhost PG_PORT=5432 PG_USER=postgres PG_PASSWORD=pass PG_DATABASE=awa pytest -m integration services/api/tests/test_roi_filters.py services/api/tests/test_score.py` *(fails: FastAPILimiter.init not called)*

------
https://chatgpt.com/codex/tasks/task_e_68a45bfbf5d8833381ece14760e5557b