### PR TITLE
Fix auth imports and cleanup API startup

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -83,7 +83,10 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
-        await FastAPILimiter.close()
+        try:
+            await FastAPILimiter.close()
+        except RuntimeError:
+            pass
 
 
 app = FastAPI(lifespan=lifespan)

--- a/services/api/routes/roi.py
+++ b/services/api/routes/roi.py
@@ -13,13 +13,15 @@ from sqlalchemy.types import Numeric
 from starlette import status
 
 from services.common.dsn import build_dsn
+
 from .. import roi_repository
 from ..db import get_session
 
 try:
     from ..security import require_basic_auth
 except Exception:  # pragma: no cover - fallback if security missing
-    require_basic_auth = lambda: None
+    def require_basic_auth() -> None:
+        return None
 
 
 router = APIRouter()

--- a/services/api/routes/score.py
+++ b/services/api/routes/score.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
+
+import os
 from typing import List, Optional
-from pydantic import BaseModel, Field, constr
+
 from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, constr
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-import os
 
 # Reuse existing dependencies if present:
 try:
@@ -13,9 +15,12 @@ except Exception:  # pragma: no cover - fallback if dependencies missing
     def get_db():
         return None
 try:
-    from services.api.security import require_basic_auth  # dependency that raises on bad creds
+    from services.api.security import (
+        require_basic_auth,  # dependency that raises on bad creds
+    )
 except Exception:
-    require_basic_auth = lambda: None  # no-op if project already handles auth globally
+    def require_basic_auth() -> None:  # no-op if project already handles auth globally
+        return None
 
 # Fallback to repository helper if available
 try:

--- a/services/api/routes/stats.py
+++ b/services/api/routes/stats.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
+
 try:
     from services.api.security import require_basic_auth
 except Exception:
-    require_basic_auth = lambda: None
+    def require_basic_auth() -> None:
+        return None
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 

--- a/services/api/security.py
+++ b/services/api/security.py
@@ -1,12 +1,14 @@
 import os
+
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from starlette.status import HTTP_401_UNAUTHORIZED
 
 _security = HTTPBasic()
-_USER = os.getenv("API_BASIC_USER", "admin")
-_PASS = os.getenv("API_BASIC_PASS", "admin")
+
 
 def require_basic_auth(credentials: HTTPBasicCredentials = Depends(_security)) -> None:
-    if not (credentials and credentials.username == _USER and credentials.password == _PASS):
+    user = os.getenv("API_BASIC_USER", "admin")
+    password = os.getenv("API_BASIC_PASS", "admin")
+    if not (credentials and credentials.username == user and credentials.password == password):
         raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Unauthorized", headers={"WWW-Authenticate": "Basic"})

--- a/services/api/tests/test_roi_basic_auth.py
+++ b/services/api/tests/test_roi_basic_auth.py
@@ -1,5 +1,6 @@
-import os
 import base64
+import os
+
 import pytest
 from fastapi.testclient import TestClient
 

--- a/services/api/tests/test_roi_filters.py
+++ b/services/api/tests/test_roi_filters.py
@@ -1,7 +1,8 @@
 import os
+
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
-import pytest
 
 pytestmark = pytest.mark.integration
 

--- a/services/api/tests/test_score.py
+++ b/services/api/tests/test_score.py
@@ -1,7 +1,9 @@
 import os
+
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
-import pytest
+
 pytestmark = pytest.mark.integration
 
 

--- a/services/api/tests/test_stats_contracts.py
+++ b/services/api/tests/test_stats_contracts.py
@@ -1,6 +1,8 @@
 import os
-from fastapi.testclient import TestClient
+
 import pytest
+from fastapi.testclient import TestClient
+
 pytestmark = pytest.mark.unit
 
 def client_with_auth():


### PR DESCRIPTION
## Summary
- sort API imports and replace lambda fallbacks with proper functions
- load basic auth credentials at request time
- guard FastAPILimiter shutdown against closed event loop

## Root Cause
- Ruff failed due to unsorted imports and lambda assignments in API routes and tests, causing CI to stop before running tests.
- Basic auth credentials were read at import time and not updated per test, and closing the rate limiter during app shutdown raised `RuntimeError: Event loop is closed`.

## Fix
- Reordered imports across API routes and tests
- Converted lambda fallbacks to `def` functions and fetched credentials from environment inside `require_basic_auth`
- Wrapped `FastAPILimiter.close()` in a `try`/`except RuntimeError`

## Repro Steps
- `ruff check services/api`
- `pytest -q --cov=services` *(requires running Postgres and Redis)*

## Risk
- Low: changes are limited to auth helper and startup/shutdown paths.

## Links
- `ci-logs/latest/CI/0_unit.txt`
- `ci-logs/latest/test/0_test.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a46baff52c83339f5d6e19b3e1e672