### PR TITLE
Use context-managed TestClient and format API modules

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -179,5 +179,3 @@ async def _check_llm() -> None:
             await cli.get(f"{LAN_BASE}/health")
     except Exception:
         os.environ["LLM_PROVIDER"] = LLM_PROVIDER_FALLBACK
-
-

--- a/services/api/roi_repository.py
+++ b/services/api/roi_repository.py
@@ -14,6 +14,7 @@ def _roi_view_name() -> str:
     # Used for SELECTs; production keeps default "v_roi_full"
     return ROI_VIEW_NAME
 
+
 ROI_SQL = text(
     f"""
     SELECT p.asin, p.title, p.category,

--- a/services/api/routes/roi.py
+++ b/services/api/routes/roi.py
@@ -20,6 +20,7 @@ from ..db import get_session
 try:
     from ..security import require_basic_auth
 except Exception:  # pragma: no cover - fallback if security missing
+
     def require_basic_auth() -> None:
         return None
 

--- a/services/api/routes/stats.py
+++ b/services/api/routes/stats.py
@@ -5,20 +5,25 @@ from fastapi import APIRouter, Depends
 try:
     from services.api.security import require_basic_auth
 except Exception:
+
     def require_basic_auth() -> None:
         return None
 
+
 router = APIRouter(prefix="/stats", tags=["stats"])
+
 
 @router.get("/kpi", dependencies=[Depends(require_basic_auth)])
 def kpi():
     # Placeholder contract; replace with real aggregates in future PRs
     return {"kpi": {"roi_avg": 0.0, "products": 0, "vendors": 0}}
 
+
 @router.get("/roi_by_vendor", dependencies=[Depends(require_basic_auth)])
 def roi_by_vendor():
     # Placeholder contract; replace with real breakdown
     return {"items": [], "total_vendors": 0}
+
 
 @router.get("/roi_trend", dependencies=[Depends(require_basic_auth)])
 def roi_trend():

--- a/services/api/security.py
+++ b/services/api/security.py
@@ -10,5 +10,13 @@ _security = HTTPBasic()
 def require_basic_auth(credentials: HTTPBasicCredentials = Depends(_security)) -> None:
     user = os.getenv("API_BASIC_USER", "admin")
     password = os.getenv("API_BASIC_PASS", "admin")
-    if not (credentials and credentials.username == user and credentials.password == password):
-        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Unauthorized", headers={"WWW-Authenticate": "Basic"})
+    if not (
+        credentials
+        and credentials.username == user
+        and credentials.password == password
+    ):
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized",
+            headers={"WWW-Authenticate": "Basic"},
+        )

--- a/services/api/tests/test_roi_basic_auth.py
+++ b/services/api/tests/test_roi_basic_auth.py
@@ -14,36 +14,37 @@ def _auth_headers(u, p):
 
 def _client():
     from services.api.main import app
+
     return TestClient(app)
 
 
 def test_roi_needs_basic_auth(monkeypatch):
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    client = _client()
-    r = client.get("/roi")  # no auth
-    assert r.status_code in (401, 403)
+    with _client() as client:
+        r = client.get("/roi")  # no auth
+        assert r.status_code in (401, 403)
 
 
 def test_roi_basic_auth_good(monkeypatch):
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    client = _client()
-    r = client.get("/roi", headers=_auth_headers("u", "p"))
-    assert r.status_code == 200
+    with _client() as client:
+        r = client.get("/roi", headers=_auth_headers("u", "p"))
+        assert r.status_code == 200
 
 
 def test_score_needs_basic_auth():
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    client = _client()
-    r = client.post("/score", json={"asins": ["A1"]})  # no auth
-    assert r.status_code in (401, 403)
+    with _client() as client:
+        r = client.post("/score", json={"asins": ["A1"]})  # no auth
+        assert r.status_code in (401, 403)
 
 
 def test_stats_contract_needs_basic_auth():
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    client = _client()
-    r = client.get("/stats/kpi")
-    assert r.status_code in (401, 403)
+    with _client() as client:
+        r = client.get("/stats/kpi")
+        assert r.status_code in (401, 403)

--- a/services/api/tests/test_roi_filters.py
+++ b/services/api/tests/test_roi_filters.py
@@ -9,32 +9,38 @@ pytestmark = pytest.mark.integration
 
 def _auth_headers():
     import base64
+
     token = base64.b64encode(b"u:p").decode()
     return {"Authorization": f"Basic {token}"}
 
 
 def setup_test_view(pg_engine):
     with pg_engine.begin() as c:
-        c.execute(text("""
+        c.execute(
+            text("""
             CREATE TABLE IF NOT EXISTS test_roi_view(
                 asin text primary key,
                 vendor text,
                 category text,
                 roi numeric
             );
-        """))
+        """)
+        )
         c.execute(text("TRUNCATE test_roi_view;"))
-        c.execute(text("""
+        c.execute(
+            text("""
             INSERT INTO test_roi_view(asin,vendor,category,roi) VALUES
             ('A1','V1','Beauty', 45.0),
             ('A2','V1','Electronics', 10.0),
             ('A3','V2','Beauty', 75.0),
             ('A4','V3','Sports', 30.0)
-        """))
+        """)
+        )
 
 
 def client():
     from services.api.main import app
+
     return TestClient(app)
 
 

--- a/services/api/tests/test_score.py
+++ b/services/api/tests/test_score.py
@@ -9,30 +9,36 @@ pytestmark = pytest.mark.integration
 
 def _auth_headers():
     import base64
+
     token = base64.b64encode(b"u:p").decode()
     return {"Authorization": f"Basic {token}"}
 
 
 def setup_test_view(pg_engine):
     with pg_engine.begin() as c:
-        c.execute(text("""
+        c.execute(
+            text("""
             CREATE TABLE IF NOT EXISTS test_roi_view(
                 asin text primary key,
                 vendor text,
                 category text,
                 roi numeric
             );
-        """))
+        """)
+        )
         c.execute(text("TRUNCATE test_roi_view;"))
-        c.execute(text("""
+        c.execute(
+            text("""
             INSERT INTO test_roi_view(asin,vendor,category,roi) VALUES
             ('A1','V1','Beauty', 55.5),
             ('A3','V2','Beauty', 12.0)
-        """))
+        """)
+        )
 
 
 def client():
     from services.api.main import app
+
     return TestClient(app)
 
 

--- a/services/api/tests/test_stats_contracts.py
+++ b/services/api/tests/test_stats_contracts.py
@@ -1,41 +1,53 @@
 import os
+from contextlib import contextmanager
 
 import pytest
 from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.unit
 
+
+@contextmanager
 def client_with_auth():
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
     from services.api.main import app
-    return TestClient(app), ("u", "p")
+
+    with TestClient(app) as client:
+        yield client, ("u", "p")
+
 
 def _auth_headers(u, p):
     import base64
+
     token = base64.b64encode(f"{u}:{p}".encode()).decode()
     return {"Authorization": f"Basic {token}"}
 
+
 def test_kpi_contract():
-    client, up = client_with_auth()
-    r = client.get("/stats/kpi", headers=_auth_headers(*up))
-    assert r.status_code == 200
-    data = r.json()
-    assert "kpi" in data and {"roi_avg","products","vendors"} <= set(data["kpi"].keys())
-    assert isinstance(data["kpi"]["roi_avg"], (int, float))
+    with client_with_auth() as (client, up):
+        r = client.get("/stats/kpi", headers=_auth_headers(*up))
+        assert r.status_code == 200
+        data = r.json()
+        assert "kpi" in data and {"roi_avg", "products", "vendors"} <= set(
+            data["kpi"].keys()
+        )
+        assert isinstance(data["kpi"]["roi_avg"], (int, float))
+
 
 def test_roi_by_vendor_contract():
-    client, up = client_with_auth()
-    r = client.get("/stats/roi_by_vendor", headers=_auth_headers(*up))
-    assert r.status_code == 200
-    data = r.json()
-    assert "items" in data and "total_vendors" in data
-    assert isinstance(data["items"], list)
+    with client_with_auth() as (client, up):
+        r = client.get("/stats/roi_by_vendor", headers=_auth_headers(*up))
+        assert r.status_code == 200
+        data = r.json()
+        assert "items" in data and "total_vendors" in data
+        assert isinstance(data["items"], list)
+
 
 def test_roi_trend_contract():
-    client, up = client_with_auth()
-    r = client.get("/stats/roi_trend", headers=_auth_headers(*up))
-    assert r.status_code == 200
-    data = r.json()
-    assert "points" in data
-    assert isinstance(data["points"], list)
+    with client_with_auth() as (client, up):
+        r = client.get("/stats/roi_trend", headers=_auth_headers(*up))
+        assert r.status_code == 200
+        data = r.json()
+        assert "points" in data
+        assert isinstance(data["points"], list)


### PR DESCRIPTION
## Summary
- format API and test modules to satisfy `ruff format --check`
- use `with TestClient(app)` in ROI and stats tests to prevent closed event loop errors

## Root Cause
- CI's `ruff format --check` failed because several API modules and tests were not formatted, aborting the unit job
- ROI authentication and stats contract tests instantiated `TestClient` without a context manager, leaving the event loop closed during subsequent requests

## Fix
- Reformat affected API modules and tests with `ruff format`
- Wrap `TestClient` usage in `with` blocks and context managers for ROI and stats tests

## Repro Steps
- `pip install -r requirements-dev.txt && pip install keepa==1.3.15 minio==7.1.15`
- `ruff check services/api/main.py services/api/roi_repository.py services/api/routes/{roi,score,stats}.py services/api/security.py services/api/tests/test_roi_basic_auth.py services/api/tests/test_roi_filters.py services/api/tests/test_score.py services/api/tests/test_stats_contracts.py`
- `ruff format --check .`
- `pytest` *(requires running Postgres service)*

## Risk
- Low; changes are limited to formatting and test client usage

## Links
- `ci-logs/latest/CI/0_unit.txt`
- `ci-logs/latest/test/0_test.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a4721def588333b96071ca3a93df54