### PR TITLE
fix ROI basic auth test setup

### DIFF
--- a/services/api/tests/test_roi_basic_auth.py
+++ b/services/api/tests/test_roi_basic_auth.py
@@ -2,6 +2,7 @@ import base64
 import os
 
 import pytest
+from contextlib import contextmanager
 from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.unit
@@ -12,16 +13,63 @@ def _auth_headers(u, p):
     return {"Authorization": f"Basic {token}"}
 
 
-def _client():
-    from services.api.main import app
+@contextmanager
+def _client(monkeypatch):
+    monkeypatch.setenv("PG_USER", "postgres")
+    monkeypatch.setenv("PG_PASSWORD", "pass")
+    monkeypatch.setenv("PG_DATABASE", "awa")
+    monkeypatch.setenv("PG_HOST", "localhost")
+    monkeypatch.setenv("PG_PORT", "5432")
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://postgres:pass@localhost:5432/awa"
+    )
 
-    return TestClient(app)
+    import services.api.main as main
+    from services.api import db
+    from fastapi_limiter import FastAPILimiter
+
+    class _DummyRedis:
+        async def evalsha(self, *args, **kwargs):  # pragma: no cover - simple stub
+            return 0
+
+    async def _noop(*args, **kwargs) -> None:  # pragma: no cover - simple stub
+        return None
+
+    async def _fake_init(redis):  # pragma: no cover - simple stub
+        FastAPILimiter.redis = _DummyRedis()
+
+    async def _fake_close():  # pragma: no cover - simple stub
+        FastAPILimiter.redis = None
+
+    monkeypatch.setattr(main, "_wait_for_db", _noop)
+    monkeypatch.setattr(FastAPILimiter, "init", _fake_init)
+    monkeypatch.setattr(FastAPILimiter, "close", _fake_close)
+
+    class FakeSession:
+        async def execute(self, query, params=None):  # pragma: no cover - simple stub
+            class Result:
+                def mappings(self):
+                    class Rows:
+                        def all(self):
+                            return []
+
+                    return Rows()
+
+            return Result()
+
+    async def fake_get_session():
+        yield FakeSession()
+
+    main.app.dependency_overrides[db.get_session] = fake_get_session
+    with TestClient(main.app) as client:
+        yield client
+    main.app.dependency_overrides.clear()
 
 
 def test_roi_needs_basic_auth(monkeypatch):
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    with _client() as client:
+    with _client(monkeypatch) as client:
         r = client.get("/roi")  # no auth
         assert r.status_code in (401, 403)
 
@@ -29,22 +77,22 @@ def test_roi_needs_basic_auth(monkeypatch):
 def test_roi_basic_auth_good(monkeypatch):
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    with _client() as client:
+    with _client(monkeypatch) as client:
         r = client.get("/roi", headers=_auth_headers("u", "p"))
         assert r.status_code == 200
 
 
-def test_score_needs_basic_auth():
+def test_score_needs_basic_auth(monkeypatch):
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    with _client() as client:
+    with _client(monkeypatch) as client:
         r = client.post("/score", json={"asins": ["A1"]})  # no auth
         assert r.status_code in (401, 403)
 
 
-def test_stats_contract_needs_basic_auth():
+def test_stats_contract_needs_basic_auth(monkeypatch):
     os.environ["API_BASIC_USER"] = "u"
     os.environ["API_BASIC_PASS"] = "p"
-    with _client() as client:
+    with _client(monkeypatch) as client:
         r = client.get("/stats/kpi")
         assert r.status_code in (401, 403)


### PR DESCRIPTION
## Summary
- stub database and rate limiter in ROI basic auth tests so they no longer rely on other modules

## Root Cause
- `services/api/tests/test_roi_basic_auth.py` used `TestClient` without overriding the DB session, causing it to reuse the CORS test's stub that didn't handle query parameters, leading to a `TypeError` during `/roi` requests.

## Fix
- introduce `_client` context manager that sets required env vars
- patch DB session, startup checks, and rate limiter with lightweight stubs
- clear dependency overrides after each use

## Repro Steps
- `pytest services/api/tests/test_roi_basic_auth.py::test_roi_basic_auth_good -q --cov-fail-under=0`

## Risk
- Low: changes affect only unit test scaffolding; production code untouched.

## Links
- ci-logs/latest/CI/0_unit.txt


------
https://chatgpt.com/codex/tasks/task_e_68a48541e09483339d024839ab18637f