### PR TITLE
Fix import ordering in ROI auth test

### DIFF
--- a/services/api/tests/test_roi_basic_auth.py
+++ b/services/api/tests/test_roi_basic_auth.py
@@ -1,8 +1,8 @@
 import base64
 import os
+from contextlib import contextmanager
 
 import pytest
-from contextlib import contextmanager
 from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.unit
@@ -24,9 +24,10 @@ def _client(monkeypatch):
         "DATABASE_URL", "postgresql+asyncpg://postgres:pass@localhost:5432/awa"
     )
 
+    from fastapi_limiter import FastAPILimiter
+
     import services.api.main as main
     from services.api import db
-    from fastapi_limiter import FastAPILimiter
 
     class _DummyRedis:
         async def evalsha(self, *args, **kwargs):  # pragma: no cover - simple stub


### PR DESCRIPTION
## Summary
- fix import sorting in ROI basic auth test to satisfy ruff I001

## Root Cause
- `services/api/tests/test_roi_basic_auth.py` had unsorted import blocks, causing `ruff` to fail the CI job.

## Fix
- sort imports in `test_roi_basic_auth.py`

## Repro Steps
- `ruff check services/api/tests/test_roi_basic_auth.py`
- `ruff format --check services/api/tests/test_roi_basic_auth.py`
- `pytest services/api/tests/test_roi_basic_auth.py::test_roi_basic_auth_good --no-cov -q`

## Risk
- Low: only affects test import ordering and does not change runtime logic.

## Links
- `ci-logs/latest/CI/0_unit.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a49149fe60833381c27bf290b3e882