### PR TITLE
Ensure fees ingestor test uses correct table schema

### DIFF
--- a/services/fees_h10/repository.py
+++ b/services/fees_h10/repository.py
@@ -10,10 +10,7 @@ def _fees_table() -> str:
 
 
 def upsert_fees_raw(
-    engine: Engine,
-    rows: Iterable[Mapping[str, Any]],
-    *,
-    testing: bool = False,
+    engine: Engine, rows: Iterable[Mapping[str, Any]], *, testing: bool = False
 ) -> Optional[Dict[str, int]]:
     """Idempotent upsert for fees.
 
@@ -40,9 +37,9 @@ def upsert_fees_raw(
             params[f"{c}{i}"] = r.get(c)
 
     insert_sql = f"""
-    INSERT INTO {tbl} ({', '.join(cols)})
+    INSERT INTO {tbl} ({", ".join(cols)})
     VALUES {values_sql}
-    ON CONFLICT ({', '.join(keys)}) DO NOTHING;
+    ON CONFLICT ({", ".join(keys)}) DO NOTHING;
     """
 
     values_cols = ", ".join([f"{c}" for c in cols])

--- a/services/fees_h10/worker.py
+++ b/services/fees_h10/worker.py
@@ -71,11 +71,7 @@ async def _bulk(asins: list[str]) -> None:
     if not url:
         return
     engine = create_engine(url.replace("+asyncpg", "+psycopg"), future=True)
-    summary = repo.upsert_fees_raw(
-        engine,
-        rows,
-        testing=os.getenv("TESTING") == "1",
-    )
+    summary = repo.upsert_fees_raw(engine, rows, testing=os.getenv("TESTING") == "1")
     if summary and os.getenv("TESTING") == "1":
         logging.info("h10 upsert summary %s", summary)
     engine.dispose()

--- a/tests/test_sp_fees_ingestor.py
+++ b/tests/test_sp_fees_ingestor.py
@@ -39,7 +39,8 @@ sys.modules["pg_utils"] = types.SimpleNamespace(connect=fake_connect)  # type: i
 sp_fees_ingestor.connect = fake_connect
 
 
-def test_offline(monkeypatch, tmp_path):
+def test_offline(monkeypatch, tmp_path, pg_engine, ensure_test_fees_raw_table) -> None:
+    os.environ["FEES_RAW_TABLE"] = "test_fees_raw"
     os.environ["ENABLE_LIVE"] = "0"
     os.environ["SP_REFRESH_TOKEN"] = "t"
     os.environ["SP_CLIENT_ID"] = "i"
@@ -47,5 +48,6 @@ def test_offline(monkeypatch, tmp_path):
     os.environ["SELLER_ID"] = "seller"
     os.environ["REGION"] = "EU"
     os.environ["DATABASE_URL"] = build_dsn(sync=True)
+    _ = pg_engine, ensure_test_fees_raw_table
     res = sp_fees_ingestor.main()
     assert res == 0


### PR DESCRIPTION
## Summary
- fix sp fees ingestor offline test to use test table matching `fees_raw` schema
- format `fees_h10` repository and worker modules

## Root Cause
- Pre-commit failed because `services/fees_h10/repository.py` and `services/fees_h10/worker.py` were not formatted, causing the `CI` workflow to exit early.
- `tests/test_sp_fees_ingestor.py::test_offline` inserted rows into the default `fees_raw` table, which lacks the `marketplace` column expected by the repository, leading to a SQL error.

## Fix
- Apply `ruff format` to `services/fees_h10/repository.py` and `services/fees_h10/worker.py`.
- Update `tests/test_sp_fees_ingestor.py` to create and target the `test_fees_raw` table via fixtures so the expected columns exist.

## Repro Steps
- `ruff check services/fees_h10/repository.py services/fees_h10/worker.py tests/test_sp_fees_ingestor.py`
- `pytest tests/test_sp_fees_ingestor.py::test_offline -q` *(requires running Postgres service)*

## Risk
- Low: changes are limited to formatting and test configuration.

## Links
- `ci-logs/latest/CI/0_unit.txt`
- `ci-logs/latest/test/1_test.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a4a31bf67883338675a9f3b5a32137