### PR TITLE
fix: cast effective_date to date

### DIFF
--- a/services/fees_h10/repository.py
+++ b/services/fees_h10/repository.py
@@ -28,8 +28,12 @@ def upsert_fees_raw(
     mutable = ("amount", "currency", "source", "effective_date")
 
     cols = keys + mutable
+
+    def _param(c: str, i: int) -> str:
+        return f":{c}{i}::DATE" if c == "effective_date" else f":{c}{i}"
+
     values_sql = ", ".join(
-        [f"({', '.join([f':{c}{i}' for c in cols])})" for i in range(len(rows))]
+        [f"({', '.join([_param(c, i) for c in cols])})" for i in range(len(rows))]
     )
     params: Dict[str, Any] = {}
     for i, r in enumerate(rows):
@@ -44,7 +48,7 @@ def upsert_fees_raw(
 
     values_cols = ", ".join([f"{c}" for c in cols])
     values_pairs = ", ".join(
-        [f"({', '.join([f':{c}{i}' for c in cols])})" for i in range(len(rows))]
+        [f"({', '.join([_param(c, i) for c in cols])})" for i in range(len(rows))]
     )
     set_assign = ", ".join([f"{m} = v.{m}" for m in mutable])
     is_changed = " OR ".join([f"t.{m} IS DISTINCT FROM v.{m}" for m in mutable])


### PR DESCRIPTION
## Summary
- fix fees upsert SQL by casting effective_date parameters to DATE

## Root Cause
- PostgreSQL rejected comparisons between `effective_date` from the CTE and the table column, raising `operator does not exist: date = text` when the value was NULL or untyped

## Fix
- cast `effective_date` placeholders to `DATE` in the upsert query builder

## Repro Steps
- `ruff check services/fees_h10/repository.py`
- `ruff format --check services/fees_h10/repository.py`
- `black --check services/fees_h10/repository.py`
- `pytest -q --cov=services` *(fails locally: no running Postgres/Redis)*

## Risks
- Minimal: affects only fees upsert query; ensures type consistency for `effective_date`

## Links
- ci-logs/latest/CI/unit/12_Pytest.txt


------
https://chatgpt.com/codex/tasks/task_e_68a4dad5d9108333b96d29711dd4f638