### PR TITLE
feat(logistics+stats): upsert_many semantics, SQL-ready /stats, cov ≥75% (PR#6)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -77,3 +77,26 @@ pytest -m integration tests/fees
 ```
 
 The repository performs two-phase writes (INSERT .. DO NOTHING + UPDATE with IS DISTINCT FROM) so unchanged rows are not updated.
+
+### Logistics ETL and /stats SQL mode
+
+**Logistics upsert_many (integration)**
+```bash
+export TESTING=1
+pytest -m integration tests/logistics -q
+```
+
+The helper `repository._upsert_many_with_keys()` exists only when TESTING=1 and lets tests assert conflict/update semantics.
+
+**/stats with real SQL aggregates (integration)**
+
+```bash
+export TESTING=1
+export STATS_USE_SQL=1
+export ROI_VIEW_NAME=test_roi_view
+export API_BASIC_USER=u
+export API_BASIC_PASS=p
+pytest -m integration services/api/tests/test_stats_sql.py -q
+```
+
+With `STATS_USE_SQL=0` (default) the API returns the stable placeholder contracts added in PR#3.

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,4 @@ markers =
     live: talks to real external APIs or network (skipped by default)
     future: placeholders for not-yet-implemented behavior (often xfail)
     slow: large datasets or long-running cases
-addopts = -q --cov=services --cov-report=xml --cov-fail-under=65 -m "not integration and not live"
+addopts = -q --cov=services --cov-report=xml --cov-fail-under=75 -m "not integration and not live"

--- a/services/api/routes/stats.py
+++ b/services/api/routes/stats.py
@@ -1,31 +1,96 @@
 from __future__ import annotations
 
+import os
 from fastapi import APIRouter, Depends
+from sqlalchemy import text
 
+try:
+    from services.api.dependencies import get_db
+except Exception:
+    get_db = None
 try:
     from services.api.security import require_basic_auth
 except Exception:
-
-    def require_basic_auth() -> None:
-        return None
-
+    require_basic_auth = lambda: None
+try:
+    from services.api import roi_repository as repo
+except Exception:
+    repo = None
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
 
+def _roi_view_name():
+    if repo and hasattr(repo, "_roi_view_name"):
+        return repo._roi_view_name()
+    return os.getenv("ROI_VIEW_NAME", "v_roi_full")
+
+
 @router.get("/kpi", dependencies=[Depends(require_basic_auth)])
-def kpi():
-    # Placeholder contract; replace with real aggregates in future PRs
+def kpi(db=Depends(get_db) if get_db else None):
+    if os.getenv("STATS_USE_SQL") == "1" and db is not None:
+        view = _roi_view_name()
+        row = db.execute(
+            text(
+                f"SELECT AVG(roi) AS roi_avg, COUNT(DISTINCT asin) AS products, COUNT(DISTINCT vendor) AS vendors FROM {view}"
+            )
+        ).mappings().first()
+        return {
+            "kpi": {
+                "roi_avg": float(row.get("roi_avg") or 0.0),
+                "products": int(row.get("products") or 0),
+                "vendors": int(row.get("vendors") or 0),
+            }
+        }
     return {"kpi": {"roi_avg": 0.0, "products": 0, "vendors": 0}}
 
 
 @router.get("/roi_by_vendor", dependencies=[Depends(require_basic_auth)])
-def roi_by_vendor():
-    # Placeholder contract; replace with real breakdown
+def roi_by_vendor(db=Depends(get_db) if get_db else None):
+    if os.getenv("STATS_USE_SQL") == "1" and db is not None:
+        view = _roi_view_name()
+        rows = db.execute(
+            text(
+                f"SELECT vendor, AVG(roi) AS roi_avg, COUNT(*) AS items FROM {view} GROUP BY vendor ORDER BY vendor"
+            )
+        ).mappings().all()
+        return {
+            "items": [
+                {
+                    "vendor": r["vendor"],
+                    "roi_avg": float(r.get("roi_avg") or 0.0),
+                    "items": int(r.get("items") or 0),
+                }
+                for r in rows
+            ],
+            "total_vendors": len(rows),
+        }
     return {"items": [], "total_vendors": 0}
 
 
 @router.get("/roi_trend", dependencies=[Depends(require_basic_auth)])
-def roi_trend():
-    # Placeholder contract; replace with real time series
+def roi_trend(db=Depends(get_db) if get_db else None):
+    if os.getenv("STATS_USE_SQL") == "1" and db is not None:
+        view = _roi_view_name()
+        for date_col in ("dt", "date", "snapshot_date", "created_at"):
+            try:
+                rows = db.execute(
+                    text(
+                        f"SELECT date_trunc('month', {date_col})::date AS month, AVG(roi) AS roi_avg, COUNT(*) AS items FROM {view} GROUP BY 1 ORDER BY 1"
+                    )
+                ).mappings().all()
+                if rows:
+                    return {
+                        "points": [
+                            {
+                                "month": str(r["month"]),
+                                "roi_avg": float(r.get("roi_avg") or 0.0),
+                                "items": int(r.get("items") or 0),
+                            }
+                            for r in rows
+                        ]
+                    }
+            except Exception:
+                continue
+        return {"points": []}
     return {"points": []}

--- a/services/api/tests/test_stats_future_contracts.py
+++ b/services/api/tests/test_stats_future_contracts.py
@@ -1,0 +1,22 @@
+import os, pytest
+from fastapi.testclient import TestClient
+pytestmark = pytest.mark.future
+
+
+def client_with_auth():
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    from services.api.main import app
+    return TestClient(app), ("u", "p")
+
+
+def _auth_headers(u, p):
+    import base64
+    return {"Authorization": f"Basic {base64.b64encode(f'{u}:{p}'.encode()).decode()}"}
+
+
+def test_stats_contracts_stable_shapes():
+    c, up = client_with_auth()
+    for path in ("/stats/kpi", "/stats/roi_by_vendor", "/stats/roi_trend"):
+        r = c.get(path, headers=_auth_headers(*up))
+        assert r.status_code == 200

--- a/services/api/tests/test_stats_sql.py
+++ b/services/api/tests/test_stats_sql.py
@@ -1,0 +1,66 @@
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _auth_headers():
+    import base64
+    token = base64.b64encode(b"u:p").decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def setup_test_view(pg_engine):
+    with pg_engine.begin() as c:
+        c.execute(text("""
+            CREATE TABLE IF NOT EXISTS test_roi_view(
+                asin text,
+                vendor text,
+                category text,
+                roi numeric,
+                dt date
+            );
+        """))
+        c.execute(text("TRUNCATE test_roi_view;"))
+        c.execute(text("""
+            INSERT INTO test_roi_view(asin,vendor,category,roi,dt) VALUES
+            ('A1','V1','Beauty', 50.0, '2024-01-15'),
+            ('A2','V1','Beauty', 10.0, '2024-02-10'),
+            ('A3','V2','Sports', 70.0, '2024-02-20'),
+            ('A4','V2','Sports', 30.0, '2024-03-05');
+        """))
+
+
+def client():
+    from services.api.main import app
+    return TestClient(app)
+
+
+def test_stats_sql_mode_kpi_vendor_trend(pg_engine, monkeypatch):
+    os.environ["TESTING"] = "1"
+    os.environ["STATS_USE_SQL"] = "1"
+    os.environ["ROI_VIEW_NAME"] = "test_roi_view"
+    os.environ["API_BASIC_USER"] = "u"
+    os.environ["API_BASIC_PASS"] = "p"
+    setup_test_view(pg_engine)
+
+    c = client()
+
+    r = c.get("/stats/kpi", headers=_auth_headers())
+    assert r.status_code == 200
+    kpi = r.json()["kpi"]
+    assert kpi["products"] == 4 and kpi["vendors"] == 2
+    assert 39.9 < kpi["roi_avg"] < 40.1
+
+    r = c.get("/stats/roi_by_vendor", headers=_auth_headers())
+    data = r.json()
+    vendors = {item["vendor"]: item for item in data["items"]}
+    assert vendors["V1"]["items"] == 2 and 29.9 < vendors["V1"]["roi_avg"] < 30.1
+    assert vendors["V2"]["items"] == 2 and 49.9 < vendors["V2"]["roi_avg"] < 50.1
+
+    r = c.get("/stats/roi_trend", headers=_auth_headers())
+    points = r.json()["points"]
+    months = {p["month"]: p for p in points}
+    assert any(m.endswith("-01") for m in months)

--- a/services/logistics_etl/repository.py
+++ b/services/logistics_etl/repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import Iterable
+import os
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
 
 from sqlalchemy import text
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from .dsn import build_dsn
@@ -30,3 +32,69 @@ async def upsert_many(rows: Iterable[dict]) -> None:
     engine = _get_engine()
     async with engine.begin() as conn:
         await conn.execute(query, list(rows))
+
+
+if os.getenv("TESTING") == "1":
+    def _upsert_many_with_keys(
+        engine: Engine,
+        *,
+        table: str,
+        key_cols: Sequence[str],
+        rows: Iterable[Mapping[str, Any]],
+        update_columns: Optional[Sequence[str]] = None,
+        testing: bool = False,
+    ) -> Optional[Dict[str, int]]:
+        """
+        TESTING-only helper: generic UPSERT into `table` with explicit `key_cols`.
+        Updates only columns listed in `update_columns` (if provided), using IS DISTINCT FROM
+        to avoid churn. Returns summary {'inserted','updated','skipped'} when testing=True.
+        """
+        incoming = list(rows)
+        if not incoming:
+            return {"inserted": 0, "updated": 0, "skipped": 0} if testing else None
+
+        # Determine columns
+        all_cols = list({k for r in incoming for k in r.keys()})
+        keys = list(key_cols)
+        if update_columns is None:
+            update_columns = [c for c in all_cols if c not in keys]
+        upd = list(update_columns)
+
+        # Build VALUES table and params
+        cols = keys + upd
+        values_rows = []
+        params: Dict[str, Any] = {}
+        for i, r in enumerate(incoming):
+            values_rows.append(f"({', '.join(f':{c}{i}' for c in cols)})")
+            for c in cols:
+                params[f"{c}{i}"] = r.get(c)
+        values_sql = ", ".join(values_rows)
+
+        insert_sql = f"""
+        INSERT INTO {table} ({", ".join(cols)})
+        VALUES {values_sql}
+        ON CONFLICT ({", ".join(keys)}) DO NOTHING;
+        """
+
+        set_assign = ", ".join([f'{c} = v.{c}' for c in upd])
+        is_changed = " OR ".join([f"t.{c} IS DISTINCT FROM v.{c}" for c in upd]) or "FALSE"
+        values_cols = ", ".join(cols)
+        update_sql = f"""
+        WITH v({values_cols}) AS (VALUES {values_sql})
+        UPDATE {table} AS t
+        SET {set_assign}
+        FROM v
+        WHERE {" AND ".join([f"t.{k} = v.{k}" for k in keys])}
+          AND ({is_changed});
+        """
+
+        inserted = updated = 0
+        with engine.begin() as conn:
+            r1 = conn.execute(text(insert_sql), params)
+            inserted = getattr(r1, "rowcount", 0) or 0
+            r2 = conn.execute(text(update_sql), params)
+            updated = getattr(r2, "rowcount", 0) or 0
+        if testing:
+            skipped = max(0, len(incoming) - (inserted + updated))
+            return {"inserted": inserted, "updated": updated, "skipped": skipped}
+        return None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,3 +2,4 @@ pytest_plugins = ["tests.helpers.factories"]
 
 pytest_plugins += ["tests.helpers.db"]
 pytest_plugins += ["tests.helpers.fees_table"]
+pytest_plugins += ["tests.helpers.logistics_table"]

--- a/tests/helpers/logistics_table.py
+++ b/tests/helpers/logistics_table.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+from sqlalchemy import text
+
+LOG_TABLE = os.getenv("LOGISTICS_TEST_TABLE", "test_logistics_routes")
+
+@pytest.fixture
+def ensure_test_logistics_table(pg_engine):
+    with pg_engine.begin() as c:
+        c.execute(text(f"""
+            CREATE TABLE IF NOT EXISTS {LOG_TABLE}(
+                lane_id text PRIMARY KEY,
+                carrier text,
+                eur_per_kg numeric,
+                updated_at timestamp with time zone DEFAULT now()
+            );
+        """))
+        c.execute(text(f"TRUNCATE {LOG_TABLE};"))
+    yield
+    with pg_engine.begin() as c:
+        c.execute(text(f"TRUNCATE {LOG_TABLE};"))

--- a/tests/logistics/test_upsert_many_concurrency.py
+++ b/tests/logistics/test_upsert_many_concurrency.py
@@ -1,0 +1,36 @@
+import os, threading
+from sqlalchemy import text
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+def test_concurrent_upserts_no_deadlock(pg_engine, ensure_test_logistics_table):
+    os.environ["TESTING"] = "1"
+    from services.logistics_etl import repository as repo
+
+    def worker(price, barrier, done):
+        barrier.wait()
+        repo._upsert_many_with_keys(
+            pg_engine,
+            table="test_logistics_routes",
+            key_cols=["lane_id"],
+            rows=[{"lane_id": "LZ", "carrier": "C1", "eur_per_kg": price}],
+            update_columns=["eur_per_kg", "updated_at"],
+            testing=False,
+        )
+        done.append(price)
+
+    barrier = threading.Barrier(2)
+    done1, done2 = [], []
+    t1 = threading.Thread(target=worker, args=(5.00, barrier, done1))
+    t2 = threading.Thread(target=worker, args=(5.20, barrier, done2))
+    t1.start(); t2.start(); t1.join(timeout=10); t2.join(timeout=10)
+    assert not t1.is_alive() and not t2.is_alive(), "Deadlock or hang in concurrent upserts"
+
+    with pg_engine.connect() as c:
+        val = float(
+            c.execute(
+                text("SELECT eur_per_kg FROM test_logistics_routes WHERE lane_id='LZ'")
+            ).scalar_one()
+        )
+    assert val in (5.00, 5.20)

--- a/tests/logistics/test_upsert_many_conflicts.py
+++ b/tests/logistics/test_upsert_many_conflicts.py
@@ -1,0 +1,51 @@
+import os
+from sqlalchemy import text
+import pytest
+
+pytestmark = pytest.mark.integration
+
+def test_updates_only_whitelisted_columns(pg_engine, ensure_test_logistics_table):
+    os.environ["TESTING"] = "1"
+    os.environ["LOGISTICS_TEST_TABLE"] = "test_logistics_routes"
+    from services.logistics_etl import repository as repo
+
+    rows1 = [
+        {"lane_id": "L1", "carrier": "DHL", "eur_per_kg": 3.50},
+        {"lane_id": "L2", "carrier": "UPS", "eur_per_kg": 4.10},
+    ]
+    # initial insert
+    s1 = repo._upsert_many_with_keys(
+        pg_engine,
+        table="test_logistics_routes",
+        key_cols=["lane_id"],
+        rows=rows1,
+        update_columns=["eur_per_kg", "updated_at"],
+        testing=True,
+    )
+    assert s1 == {"inserted": 2, "updated": 0, "skipped": 0}
+
+    # second batch: change carrier (should NOT update), change eur_per_kg (should update)
+    rows2 = [
+        {"lane_id": "L1", "carrier": "FedEx", "eur_per_kg": 3.90},
+        {"lane_id": "L2", "carrier": "UPS", "eur_per_kg": 4.10},
+    ]
+    s2 = repo._upsert_many_with_keys(
+        pg_engine,
+        table="test_logistics_routes",
+        key_cols=["lane_id"],
+        rows=rows2,
+        update_columns=["eur_per_kg", "updated_at"],
+        testing=True,
+    )
+    assert s2["inserted"] == 0 and s2["updated"] == 1 and s2["skipped"] == 1
+
+    with pg_engine.connect() as c:
+        res = dict(
+            c.execute(
+                text(
+                    "SELECT lane_id, carrier, eur_per_kg FROM test_logistics_routes WHERE lane_id='L1'"
+                )
+            ).mappings().first()
+        )
+        assert res["carrier"] == "DHL"
+        assert float(res["eur_per_kg"]) == 3.90


### PR DESCRIPTION
## Summary
- add TESTING-only `_upsert_many_with_keys` allowing explicit key/update columns
- wire `/stats` to compute aggregates from SQL when `STATS_USE_SQL=1`
- document logistics and stats integration tests
- raise coverage fail-under to 75%

## Testing
- `pytest` *(fails: redis.exceptions.ConnectionError: Error Multiple exceptions: [Errno 111] Connection refused)*
- `pytest -m integration tests/logistics services/api/tests/test_stats_sql.py -q` *(fails: coverage 2.60% < 75%)*


------
https://chatgpt.com/codex/tasks/task_e_68a4f00906148333b0eadb60b743389f