### PR TITLE
chore(test+docs+llm): enforce cov≥75, unify target, finalize TESTING.md, runtime LLM provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: pytest
         continue-on-error: false
-        run: pytest
+        run: pytest -q --cov=services --cov-report=xml --cov-fail-under=75
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: pass # pragma: allowlist secret

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -7,7 +7,7 @@ pytest
 
 By default only unit tests run (integration and live are excluded to keep CI fast).
 
-## Markers
+Markers
 
 unit — fast, pure unit tests (default).
 
@@ -25,7 +25,7 @@ future — pins future behavior; often xfail.
 
 slow — long-running or large datasets.
 
-## Coverage policy
+Coverage policy
 
 Coverage is measured on the services package and enforced at 75%:
 ```bash
@@ -34,17 +34,17 @@ pytest -q --cov=services --cov-report=xml --cov-fail-under=75
 
 CI publishes coverage.xml for external tooling.
 
-## Ingest / ETL integration tests
+Ingest / ETL integration tests
 
-These require Postgres and TESTING=1.
+Require Postgres and TESTING=1.
 ```bash
 export TESTING=1
 pytest -m integration tests/etl -q
 ```
 
-Tests use a test-only dialect test_generic and a staging table created by fixtures; production data is untouched.
+Tests use a test-only dialect test_generic; production data is untouched.
 
-## API integration tests (ROI filters and /score)
+API integration tests (ROI filters and /score)
 
 Point the API to a test ROI view/table via env.
 ```bash
@@ -56,7 +56,7 @@ pytest -m integration services/api/tests/test_roi_filters.py -q
 pytest -m integration services/api/tests/test_score.py -q
 ```
 
-## /stats in SQL mode
+/stats in SQL mode
 
 Enable real aggregates with STATS_USE_SQL=1.
 ```bash
@@ -68,18 +68,18 @@ export API_BASIC_PASS=p
 pytest -m integration services/api/tests/test_stats_sql.py -q
 ```
 
-With STATS_USE_SQL unset/0, /stats returns stable placeholder contracts.
+With STATS_USE_SQL unset/0, /stats returns the stable placeholder contracts.
 
-## Fees integrators (Helium10 / SP)
+Fees integrators (Helium10 / SP)
 
-Write to a dedicated test table chosen via FEES_RAW_TABLE.
+Write to a dedicated test table via FEES_RAW_TABLE.
 ```bash
 export TESTING=1
 export FEES_RAW_TABLE=test_fees_raw
 pytest -m integration tests/fees -q
 ```
 
-## Logistics ETL
+Logistics ETL
 
 Generic upsert helper exists only when TESTING=1.
 ```bash
@@ -87,9 +87,9 @@ export TESTING=1
 pytest -m integration tests/logistics -q
 ```
 
-## LLM module tests and defaults
+LLM module tests and defaults
 
-Provider is selected at call time via LLM_PROVIDER; default provider is lan. Useful envs:
+Provider is selected at call time via LLM_PROVIDER; default is lan. Useful envs:
 
 LLM_PROVIDER — lan | local | openai | stub (default: lan)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,4 @@ markers =
     live: talks to real external APIs or network (skipped by default)
     future: placeholders for not-yet-implemented behavior (often xfail)
     slow: large datasets or long-running cases
-addopts = -q --cov=services --cov-report=xml -m "not integration and not live"
+addopts = -q --cov=services --cov-report=xml --cov-fail-under=75 -m "not integration and not live"

--- a/services/common/llm.py
+++ b/services/common/llm.py
@@ -12,6 +12,7 @@ LAN_KEY = os.getenv("LLM_API_KEY", "")
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
+
 _LLM_PROVIDER_ENV = "LLM_PROVIDER"
 LLM_PROVIDER = os.getenv(_LLM_PROVIDER_ENV, "lan").strip().lower()
 LLM_PROVIDER_FALLBACK = os.getenv("LLM_PROVIDER_FALLBACK", "stub").strip().lower()
@@ -20,8 +21,7 @@ _REMOTE_URL_ENV = "LLM_REMOTE_URL"
 
 
 def _selected_provider() -> str:
-    # default provider is 'lan' unless overridden via LLM_PROVIDER
-    return (os.getenv(_LLM_PROVIDER_ENV) or "lan").strip().lower()
+    return (os.getenv("LLM_PROVIDER") or "lan").strip().lower()
 
 
 def _timeout_seconds(default: float = 60.0) -> float:
@@ -128,11 +128,11 @@ async def generate(
     *,
     timeout: Optional[float] = None,
 ) -> str:
+    prov = (provider or _selected_provider()).lower()
     providers = ["lan", "local", "openai", "stub"]
-    first = provider or _selected_provider()
-    if first in providers:
-        providers.remove(first)
-        providers.insert(0, first)
+    if prov in providers:
+        providers.remove(prov)
+        providers.insert(0, prov)
     last_exc: Exception | None = None
     for p in providers:
         try:


### PR DESCRIPTION
## Summary
- raise coverage fail-under to 75% on the `services` package
- enforce the same coverage gate in CI
- finalize TESTING.md with concrete commands and env examples
- select LLM provider from `LLM_PROVIDER` at call time, defaulting to `lan`

## Testing
- `pytest` *(fails: redis connection refused, database not available)*

Do not lower the coverage threshold. If CI fails the 75% coverage gate, do not reduce the threshold. Instead, apply only the allowed remediation steps below in follow-up commits within this PR (small, surgical tests only; no production code changes):

- Add a minimal import smoke test to execute module import paths that currently have zero coverage (top-level code, settings wiring), without side effects:

```python
# tests/smoke/test_imports.py
MODULES = [
    "services.api.main",
    "services.common.llm",
    "services.etl.load_csv",
    "services.fees_h10.repository",
    "services.etl.sp_fees_ingestor",
    "services.logistics_etl.repository",
]
def test_imports_smoke():
    for m in MODULES:
        __import__(m)
```

- Add tiny contract/sanity tests around existing APIs that don’t hit external services (using FastAPI TestClient with Basic Auth) to cover response shape-only paths:

```python
# tests/smoke/test_api_contracts.py
import os, base64
from fastapi.testclient import TestClient
os.environ["API_BASIC_USER"]="u"; os.environ["API_BASIC_PASS"]="p"
from services.api.main import app
H={"Authorization":"Basic "+base64.b64encode(b"u:p").decode()}
def test_stats_kpi_contract():
    r=TestClient(app).get("/stats/kpi", headers=H); assert r.status_code==200
```

- Add negative-path unit tests for existing helpers (no I/O): e.g., assert informative exceptions for empty files/missing columns in ingest, DSN/ENV validation errors, and LLM unknown provider. Keep these tests short and pure.

- Use parameterization to cheaply multiply coverage across existing tests (e.g., more delimiter/encoding combos in ingest; a couple more ROI filter combinations).

- Convert any test that currently requires external services into a unit test with mocks (e.g., mock httpx/MinIO/requests) so it runs by default and contributes to coverage.

- Mark long-running cases as @pytest.mark.slow (not skipped by default) if you need to run them locally to check coverage, but prefer unit tests for CI.

------
https://chatgpt.com/codex/tasks/task_e_68a526899e348333ae1a318be2c093b1