### PR TITLE
chore(test+docs+llm): enforce cov≥75, unify target, add TESTING.md, runtime LLM provider

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,9 +4,4 @@ omit =
     */tests/*
     */migrations/*
     */alembic/*
-    */api/models/*
-    */api/routes/*
-    */fees_h10/*
-    */ingest/*
-    */price_importer/services_common/*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Type check
         run: python -m mypy services || true
       - name: Pytest
-        run: pytest -q --cov=services
+        run: pytest -q --cov=services --cov-report=xml --cov-fail-under=75
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,14 +12,14 @@ Markers
 unit — fast, pure unit tests (default).
 
 integration — require services (Postgres/MinIO/etc.). Run explicitly:
-```bash
+
 pytest -m integration
-```
+
 
 live — real external calls; always opt-in:
-```bash
+
 pytest -m live
-```
+
 
 future — pins future behavior; often xfail.
 
@@ -28,64 +28,61 @@ slow — long-running or large datasets.
 Coverage policy
 
 Coverage is measured on the services package and enforced at 75%:
-```bash
+
 pytest -q --cov=services --cov-report=xml --cov-fail-under=75
-```
+
 
 CI publishes coverage.xml for external tooling.
 
 Ingest / ETL integration tests
 
 Require Postgres and TESTING=1.
-```bash
+
 export TESTING=1
 pytest -m integration tests/etl -q
-```
+
 
 Tests use a test-only dialect test_generic; production data is untouched.
 
 API integration tests (ROI filters and /score)
 
 Point the API to a test ROI view/table via env.
-```bash
+
 export TESTING=1
 export API_BASIC_USER=u
 export API_BASIC_PASS=p
 export ROI_VIEW_NAME=test_roi_view
 pytest -m integration services/api/tests/test_roi_filters.py -q
 pytest -m integration services/api/tests/test_score.py -q
-```
 
 /stats in SQL mode
 
 Enable real aggregates with STATS_USE_SQL=1.
-```bash
+
 export TESTING=1
 export STATS_USE_SQL=1
 export ROI_VIEW_NAME=test_roi_view
 export API_BASIC_USER=u
 export API_BASIC_PASS=p
 pytest -m integration services/api/tests/test_stats_sql.py -q
-```
+
 
 With STATS_USE_SQL unset/0, /stats returns the stable placeholder contracts.
 
 Fees integrators (Helium10 / SP)
 
 Write to a dedicated test table via FEES_RAW_TABLE.
-```bash
+
 export TESTING=1
 export FEES_RAW_TABLE=test_fees_raw
 pytest -m integration tests/fees -q
-```
 
 Logistics ETL
 
 Generic upsert helper exists only when TESTING=1.
-```bash
+
 export TESTING=1
 pytest -m integration tests/logistics -q
-```
 
 LLM module tests and defaults
 
@@ -98,6 +95,6 @@ LLM_TIMEOUT_SECS — request timeout (seconds), default 60
 LLM_REMOTE_URL — override remote HTTP endpoint in tests
 
 Run:
-```bash
+
 pytest tests/llm -q
-```
+

--- a/services/common/llm.py
+++ b/services/common/llm.py
@@ -128,7 +128,8 @@ async def generate(
     *,
     timeout: Optional[float] = None,
 ) -> str:
-    prov = (provider or _selected_provider()).lower()
+    env_prov = _selected_provider()
+    prov = (provider or env_prov).lower()
     providers = ["lan", "local", "openai", "stub"]
     if prov in providers:
         providers.remove(prov)


### PR DESCRIPTION
## Summary
- enforce coverage gate at 75% and target the whole `services` package
- document test workflow and environments
- select LLM provider at call time with `lan` default

## Testing
- `pre-commit run --files .coveragerc .github/workflows/ci.yml docs/TESTING.md services/common/llm.py` *(fails: Username for 'https://github.com')*
- `pytest -q --cov=services --cov-report=xml --cov-fail-under=75` *(fails: Database not available, async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a57fb6b5488333bd2a98ceb55f52da