### PR TITLE
Fix DSN building and test isolation

### DIFF
--- a/etl/load_csv.py
+++ b/etl/load_csv.py
@@ -5,7 +5,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, Callable, cast
+from typing import Any, Callable
 
 import boto3
 import pandas as pd
@@ -114,9 +114,9 @@ def import_file(
 
         df = td.normalize_df(df)
         engine = create_engine(build_dsn(sync=True))
-        with engine.begin() as conn:
+        with engine.begin() as db_conn:
             for row in df.to_dict(orient="records"):
-                conn.execute(
+                db_conn.execute(
                     text(
                         'INSERT INTO test_generic_raw("ASIN", qty, price) VALUES (:ASIN,:qty,:price) '
                         'ON CONFLICT ("ASIN") DO UPDATE SET qty=EXCLUDED.qty, price=EXCLUDED.price'
@@ -190,7 +190,7 @@ def import_file(
     warnings: list[str] = []
 
     engine = create_engine(build_dsn(sync=True))
-    conn = cast(Any, engine.raw_connection())
+    conn: Any = engine.raw_connection()
     try:
         conn.autocommit = False
         with conn.cursor() as cur:

--- a/services/api/routes/score.py
+++ b/services/api/routes/score.py
@@ -25,7 +25,6 @@ try:
         require_basic_auth,  # dependency that raises on bad creds
     )
 except Exception:
-
     _security = HTTPBasic()
 
     def require_basic_auth(
@@ -46,9 +45,7 @@ Asin = Annotated[str, Field(min_length=1, strip_whitespace=True)]
 
 
 class ScoreRequest(BaseModel):
-    asins: List[Asin] = Field(
-        ..., description="List of ASINs"
-    )
+    asins: List[Asin] = Field(..., description="List of ASINs")
 
 
 class ScoreItem(BaseModel):
@@ -97,9 +94,11 @@ def score(body: ScoreRequest, db: Session | None = Depends(get_db)) -> ScoreResp
                     "asin": row.asin,
                     "vendor": getattr(row, "vendor", None),
                     "category": getattr(row, "category", None),
-                    "roi": float(row.roi)
-                    if getattr(row, "roi", None) is not None
-                    else None,
+                    "roi": (
+                        float(row.roi)
+                        if getattr(row, "roi", None) is not None
+                        else None
+                    ),
                 }
     items = []
     for asin in body.asins:

--- a/services/common/config.py
+++ b/services/common/config.py
@@ -4,4 +4,3 @@ ASYNC_DSN = build_dsn(sync=False)
 SYNC_DSN = build_dsn(sync=True)
 
 __all__ = ["ASYNC_DSN", "SYNC_DSN"]
-

--- a/services/common/dsn.py
+++ b/services/common/dsn.py
@@ -14,27 +14,31 @@ def build_dsn(sync: bool = True) -> str:
     url = os.getenv("PG_SYNC_DSN" if sync else "PG_ASYNC_DSN")
     if url:
         return url.replace(
-            "postgresql://", "postgresql+psycopg://" if sync else "postgresql+asyncpg://"
+            "postgresql://",
+            "postgresql+psycopg://" if sync else "postgresql+asyncpg://",
         )
     if not url:
         other = os.getenv("PG_ASYNC_DSN" if sync else "PG_SYNC_DSN")
         if other:
             if sync:
-                return (
-                    other.replace("+asyncpg", "+psycopg")
-                    .replace("postgresql://", "postgresql+psycopg://")
+                return other.replace("+asyncpg", "+psycopg").replace(
+                    "postgresql://", "postgresql+psycopg://"
                 )
-            return (
-                other.replace("+psycopg", "+asyncpg")
-                .replace("postgresql://", "postgresql+asyncpg://")
+            return other.replace("+psycopg", "+asyncpg").replace(
+                "postgresql://", "postgresql+asyncpg://"
             )
 
     url = os.getenv("DATABASE_URL")
     if url:
-        return (
-            url.replace("+asyncpg", "+psycopg")
-            if sync
-            else url.replace("+psycopg", "+asyncpg")
+        if "+asyncpg" in url or "+psycopg" in url:
+            return (
+                url.replace("+asyncpg", "+psycopg")
+                if sync
+                else url.replace("+psycopg", "+asyncpg")
+            )
+        return url.replace(
+            "postgresql://",
+            "postgresql+psycopg://" if sync else "postgresql+asyncpg://",
         )
 
     required = ["PG_USER", "PG_PASSWORD", "PG_DATABASE", "PG_HOST", "PG_PORT"]

--- a/services/logistics_etl/dsn.py
+++ b/services/logistics_etl/dsn.py
@@ -17,27 +17,31 @@ def build_dsn(sync: bool = True) -> str:
     url = os.getenv("PG_SYNC_DSN" if sync else "PG_ASYNC_DSN")
     if url:
         return url.replace(
-            "postgresql://", "postgresql+psycopg://" if sync else "postgresql+asyncpg://"
+            "postgresql://",
+            "postgresql+psycopg://" if sync else "postgresql+asyncpg://",
         )
     if not url:
         other = os.getenv("PG_ASYNC_DSN" if sync else "PG_SYNC_DSN")
         if other:
             if sync:
-                return (
-                    other.replace("+asyncpg", "+psycopg")
-                    .replace("postgresql://", "postgresql+psycopg://")
+                return other.replace("+asyncpg", "+psycopg").replace(
+                    "postgresql://", "postgresql+psycopg://"
                 )
-            return (
-                other.replace("+psycopg", "+asyncpg")
-                .replace("postgresql://", "postgresql+asyncpg://")
+            return other.replace("+psycopg", "+asyncpg").replace(
+                "postgresql://", "postgresql+asyncpg://"
             )
 
     url = os.getenv("DATABASE_URL")
     if url:
-        return (
-            url.replace("+asyncpg", "+psycopg")
-            if sync
-            else url.replace("+psycopg", "+asyncpg")
+        if "+asyncpg" in url or "+psycopg" in url:
+            return (
+                url.replace("+asyncpg", "+psycopg")
+                if sync
+                else url.replace("+psycopg", "+asyncpg")
+            )
+        return url.replace(
+            "postgresql://",
+            "postgresql+psycopg://" if sync else "postgresql+asyncpg://",
         )
 
     required = ["PG_USER", "PG_PASSWORD", "PG_DATABASE", "PG_HOST", "PG_PORT"]

--- a/services/price_importer/services_common/dsn.py
+++ b/services/price_importer/services_common/dsn.py
@@ -13,27 +13,31 @@ def build_dsn(sync: bool = True) -> str:
     url = os.getenv("PG_SYNC_DSN" if sync else "PG_ASYNC_DSN")
     if url:
         return url.replace(
-            "postgresql://", "postgresql+psycopg://" if sync else "postgresql+asyncpg://"
+            "postgresql://",
+            "postgresql+psycopg://" if sync else "postgresql+asyncpg://",
         )
     if not url:
         other = os.getenv("PG_ASYNC_DSN" if sync else "PG_SYNC_DSN")
         if other:
             if sync:
-                return (
-                    other.replace("+asyncpg", "+psycopg")
-                    .replace("postgresql://", "postgresql+psycopg://")
+                return other.replace("+asyncpg", "+psycopg").replace(
+                    "postgresql://", "postgresql+psycopg://"
                 )
-            return (
-                other.replace("+psycopg", "+asyncpg")
-                .replace("postgresql://", "postgresql+asyncpg://")
+            return other.replace("+psycopg", "+asyncpg").replace(
+                "postgresql://", "postgresql+asyncpg://"
             )
 
     url = os.getenv("DATABASE_URL")
     if url:
-        return (
-            url.replace("+asyncpg", "+psycopg")
-            if sync
-            else url.replace("+psycopg", "+asyncpg")
+        if "+asyncpg" in url or "+psycopg" in url:
+            return (
+                url.replace("+asyncpg", "+psycopg")
+                if sync
+                else url.replace("+psycopg", "+asyncpg")
+            )
+        return url.replace(
+            "postgresql://",
+            "postgresql+psycopg://" if sync else "postgresql+asyncpg://",
         )
 
     host = os.getenv("PG_HOST", "localhost")

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -3,17 +3,21 @@ from services.common.db_url import build_url
 
 def test_build_url_from_parts(monkeypatch):
     monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("PG_SYNC_DSN", raising=False)
+    monkeypatch.delenv("PG_ASYNC_DSN", raising=False)
     monkeypatch.setenv("PG_USER", "u")
     monkeypatch.setenv("PG_PASSWORD", "p")
     monkeypatch.setenv("PG_HOST", "h")
     monkeypatch.setenv("PG_PORT", "1")
     monkeypatch.setenv("PG_DATABASE", "d")
     assert build_url() == "postgresql+asyncpg://u:p@h:1/d"
-    assert build_url(async_=False) == "postgresql://u:p@h:1/d"
+    assert build_url(async_=False) == "postgresql+psycopg://u:p@h:1/d"
 
 
 def test_build_url_toggles_database_url(monkeypatch):
+    monkeypatch.delenv("PG_SYNC_DSN", raising=False)
+    monkeypatch.delenv("PG_ASYNC_DSN", raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:1/d")
     assert build_url() == "postgresql+asyncpg://u:p@h:1/d"
     monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@h:1/d")
-    assert build_url(async_=False) == "postgresql://u:p@h:1/d"
+    assert build_url(async_=False) == "postgresql+psycopg://u:p@h:1/d"


### PR DESCRIPTION
## Summary
- ensure DSN helpers add driver names when `DATABASE_URL` omits them
- isolate DB URL tests from preset DSN variables
- address mypy false positives and format the repository

## Root Cause
- Pre-commit failed because several DSN modules and a route file were not formatted according to `ruff-format`, aborting the job.
- DB URL tests failed due to preset `PG_SYNC_DSN`/`PG_ASYNC_DSN` variables and expectations that did not match the updated DSN builder behavior.

## Fix
- add driver fallback logic to DSN builders
- clean test environment and update expected DSNs
- rename internal ETL connection variable and annotate as `Any`
- run `ruff`, `black`, and `mypy` to enforce style and typing

## Repro Steps
- `ruff format services/common/dsn.py services/logistics_etl/dsn.py services/price_importer/services_common/dsn.py`
- `mypy --explicit-package-bases -p services`
- `pytest tests/test_db_url.py -q`

## Risk
- Low: changes are limited to DSN construction and test adjustments; existing behavior remains for configured DSNs.

## Links
- `ci-logs/latest/CI/0_unit.txt`
- `ci-logs/latest/test/0_test.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a5f733da18833395a82811e4186aae