### PR TITLE
Handle sysctl failure in redis compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: ["sh", "-c", "sysctl -w vm.overcommit_memory=1 && redis-server"]
+    command: ["sh", "-c", "sysctl -w vm.overcommit_memory=1 || true; redis-server"]
     ports:
       - "6379:6379"
     healthcheck:

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -1,15 +1,16 @@
 # CI Triage
 
 ## Failing workflows
-- **CI** workflow
-- **test** workflow
+- **CI** workflow (compose-health job)
+- **test** workflow (health-checks job)
 
 ## Summary
-Both workflows invoked pytest with `--cov-fail-under=75`, overriding the project's `fail_under = 45` coverage setting and causing failures at ~65% coverage.
+Docker compose health checks failed because the Redis service exited immediately. The startup command attempted to run `sysctl -w vm.overcommit_memory=1`, which is not permitted in the execution environment, so `redis-server` never started and downstream services reported the container as unhealthy.
 
 ## Fix
-Removed the explicit `--cov-fail-under=75` flag from `.github/workflows/ci.yml`, `.github/workflows/test.yml`, and `pytest.ini` so pytest uses the configured threshold.
+- Updated `docker-compose.yml` to ignore failures from the `sysctl` command so the Redis server starts even when kernel parameters cannot be modified.
 
 ## Logs
-- `ci-logs/latest/CI/0_unit.txt`
-- `ci-logs/latest/test/2_test.txt`
+- `ci-logs/latest/CI/compose-health/6_Run export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1.txt`
+- `ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt`
+


### PR DESCRIPTION
## Summary
- ensure redis service starts in docker compose even when `sysctl` is unavailable
- document failing compose jobs in CI triage

## Root Cause
- the redis service defined `sysctl -w vm.overcommit_memory=1 && redis-server`, which exited when the runner disallowed modifying kernel parameters, leaving the container unhealthy.

## Fix
- ignore `sysctl` errors in the redis compose command so `redis-server` still launches
- record the failure in `docs/ci-triage.md`

## Repro Steps
- `docker compose up -d --wait`

## Risk
- low: only alters container startup command to be more forgiving when `sysctl` is not permitted

## Links
- ci-logs/latest/CI/compose-health/6_Run export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1.txt
- ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt

------
https://chatgpt.com/codex/tasks/task_e_68a606ac0330833394ea36fceff1a6c3