### PR TITLE
fix: adopt PEP 604 unions and run migration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,7 +195,7 @@ jobs:
         continue-on-error: false
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
-        run: pytest tests/migrations/test_migration_roundtrip.py -q --cov=services --cov-append --cov-fail-under=0
+        run: pytest tests/migrations/test_migration_roundtrip.py -q -m integration --cov=services --cov-append --cov-fail-under=0 -o addopts=''
       - uses: actions/upload-artifact@v4
         with:
           name: coverage.integration

--- a/api/routers/ingest.py
+++ b/api/routers/ingest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from celery import states
 from fastapi import APIRouter, File, HTTPException, Request, UploadFile
@@ -18,8 +18,8 @@ router = APIRouter(prefix="", tags=["ingest"])
 async def submit_ingest(
     request: Request,
     file: UploadFile | None = File(None),
-    uri: Optional[str] = None,
-    report_type: Optional[str] = None,
+    uri: str | None = None,
+    report_type: str | None = None,
     force: bool = False,
 ) -> Dict[str, Any]:
     if not file and uri is None:

--- a/services/api/routes/roi.py
+++ b/services/api/routes/roi.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import secrets
-from typing import List, Optional
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
@@ -85,8 +85,8 @@ def build_pending_sql(include_vendor: bool, include_category: bool):
 def roi_review(
     request: Request,
     roi_min: int = 0,
-    vendor: Optional[int] = None,
-    category: Optional[str] = None,
+    vendor: int | None = None,
+    category: str | None = None,
     _: str = Depends(_check_basic_auth),
 ):
     url = build_dsn(sync=True)

--- a/services/api/routes/score.py
+++ b/services/api/routes/score.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 from types import ModuleType
-from typing import Annotated, List, Optional, cast
+from typing import Annotated, List, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
@@ -50,10 +50,10 @@ class ScoreRequest(BaseModel):
 
 class ScoreItem(BaseModel):
     asin: str
-    roi: Optional[float] = None
-    vendor: Optional[str] = None
-    category: Optional[str] = None
-    error: Optional[str] = None
+    roi: float | None = None
+    vendor: str | None = None
+    category: str | None = None
+    error: str | None = None
 
 
 class ScoreResponse(BaseModel):

--- a/services/common/llm.py
+++ b/services/common/llm.py
@@ -1,6 +1,6 @@
 import importlib
 import os
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 try:
     import httpx
@@ -97,7 +97,7 @@ async def _generate_with_provider(
     *,
     temperature: float,
     max_tokens: int,
-    timeout: Optional[float] = None,
+    timeout: float | None = None,
 ) -> str:
     to = timeout or _timeout_seconds()
     if provider == "lan":
@@ -126,7 +126,7 @@ async def generate(
     max_tokens: int = 256,
     provider: str | None = None,
     *,
-    timeout: Optional[float] = None,
+    timeout: float | None = None,
 ) -> str:
     env_prov = _selected_provider()
     prov = (provider or env_prov).lower()

--- a/services/fees_h10/repository.py
+++ b/services/fees_h10/repository.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Iterable, Mapping, Optional
+from typing import Any, Dict, Iterable, Mapping
 
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
@@ -11,7 +11,7 @@ def _fees_table() -> str:
 
 def upsert_fees_raw(
     engine: Engine, rows: Iterable[Mapping[str, Any]], *, testing: bool = False
-) -> Optional[Dict[str, int]]:
+) -> dict[str, int] | None:
     """Idempotent upsert for fees.
 
     TESTING-only: returns counts for inserted/updated/skipped rows.

--- a/services/ingest/copy_loader.py
+++ b/services/ingest/copy_loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Optional, Sequence, cast
+from typing import Any, Sequence, cast
 
 import pandas as pd
 from psycopg2 import sql
@@ -13,7 +13,7 @@ def _ensure_ident(name: str) -> sql.Identifier:
     return sql.Identifier(name)
 
 
-def _fq_ident(schema: Optional[str], table: str) -> sql.SQL:
+def _fq_ident(schema: str | None, table: str) -> sql.SQL:
     if schema:
         return sql.SQL(".").join([_ensure_ident(schema), _ensure_ident(table)])
     return _ensure_ident(table)
@@ -24,9 +24,9 @@ def copy_df_via_temp(
     df: pd.DataFrame,
     target_table: str,
     *,
-    target_schema: Optional[str] = None,
+    target_schema: str | None = None,
     columns: Sequence[str],
-    conflict_cols: Optional[Sequence[str]] = None,
+    conflict_cols: Sequence[str] | None = None,
     analyze_after: bool = False,
     connection: Any | None = None,
 ) -> int:

--- a/services/logistics_etl/repository.py
+++ b/services/logistics_etl/repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, Mapping, Sequence
 
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
@@ -42,9 +42,9 @@ if os.getenv("TESTING") == "1":
         table: str,
         key_cols: Sequence[str],
         rows: Iterable[Mapping[str, Any]],
-        update_columns: Optional[Sequence[str]] = None,
+        update_columns: Sequence[str] | None = None,
         testing: bool = False,
-    ) -> Optional[Dict[str, int]]:
+    ) -> dict[str, int] | None:
         """
         TESTING-only helper: generic UPSERT into `table` with explicit `key_cols`.
         Updates only columns listed in `update_columns` (if provided), using IS DISTINCT FROM

--- a/tests/logistics/test_upsert_many_concurrency.py
+++ b/tests/logistics/test_upsert_many_concurrency.py
@@ -31,9 +31,9 @@ def test_concurrent_upserts_no_deadlock(pg_engine, ensure_test_logistics_table):
     t2.start()
     t1.join(timeout=10)
     t2.join(timeout=10)
-    assert (
-        not t1.is_alive() and not t2.is_alive()
-    ), "Deadlock or hang in concurrent upserts"
+    assert not t1.is_alive() and not t2.is_alive(), (
+        "Deadlock or hang in concurrent upserts"
+    )
 
     with pg_engine.connect() as c:
         val = float(


### PR DESCRIPTION
## Summary
- replace `Optional` annotations with PEP 604 `| None` unions
- ensure migration regression test runs by clearing default marker filters

## Root Cause
- Ruff `UP007` errors flagged legacy `Optional[...]` annotations across multiple modules, causing the linter step to fail in CI. The integration DB job invoked `pytest` without overriding the `addopts` marker filter, so the migration test was skipped and the job exited with code 5.

## Fix
- refactor type hints in API, common utilities, and repository modules to use `| None`
- update workflow to run migration test with `-m integration` and empty `addopts`
- format logistics concurrency test to satisfy `ruff format --check`

## Repro Steps
- `ruff check .`
- `ruff format --check .`
- `vulture`
- `pytest tests/migrations/test_migration_roundtrip.py -q -m integration --cov=services --cov-append --cov-fail-under=0 -o addopts=''` *(skips locally without Postgres)*

## Risk
- Minimal: only typing syntax updated and workflow command adjusted; no runtime logic changes.

## Links
- ci-logs/latest/CI/unit/7_Check code formatting.txt
- ci-logs/latest/test/1_integration-db.txt

------
https://chatgpt.com/codex/tasks/task_e_68a614db64e88333997315205b2208f5