### PR TITLE
ci: run migration regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Single head check
         run: test "$(alembic -c services/api/alembic.ini heads | wc -l)" -eq 1
       - name: Migration regression test
-        run: pytest tests/migrations/test_migration_roundtrip.py -q
+        run: pytest tests/migrations/test_migration_roundtrip.py -q -m integration
 
   container-build:
     needs: unit


### PR DESCRIPTION
## Summary
- ensure migration regression test runs in CI

## Root Cause
- the migrations-check job invoked pytest without `-m integration`, so no tests ran and CI stopped with exit code 5

## Fix
- run the migration regression test with `-m integration`

## Repro Steps
- `pip install -r requirements-dev.txt`
- `pytest tests/migrations/test_migration_roundtrip.py -q -m integration`

## Risk
- Low: adjusts CI command only

## Links
- `ci-logs/latest/CI/migrations-check/12_Migration regression test.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a620e0b9ac83338fef83d3345b23af