### PR TITLE
Fix compose health job env setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: echo "GITHUB_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
+      - name: Load env
+        run: |
+          cat .env.ci >> "$GITHUB_ENV"
+          echo "DATABASE_URL=postgresql+asyncpg://postgres:pass@localhost:5432/awa" >> "$GITHUB_ENV"
+          echo "PG_HOST=localhost" >> "$GITHUB_ENV"
+          echo "PG_PORT=5432" >> "$GITHUB_ENV"
+          echo "PG_USER=postgres" >> "$GITHUB_ENV"
+          echo "PG_PASSWORD=pass" >> "$GITHUB_ENV"
+          echo "PG_DATABASE=awa" >> "$GITHUB_ENV"
       - run: |
           export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1
           docker compose --progress=plain \


### PR DESCRIPTION
## Summary
- ensure compose-health workflow loads database and redis env vars

## Root Cause
- `compose-health` job didn't load `.env.ci`, so containers lacked required PG and redis variables causing the celery worker healthcheck to fail

## Fix
- load `.env.ci` and related env vars before running docker-compose in `compose-health`

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait --no-build --pull always`
- observe `celery_worker-1 is unhealthy` before fix

## Risk
- Low: step only exports env variables for CI workflow.

## Links
- ci-logs/latest/CI/3_compose-health.txt


------
https://chatgpt.com/codex/tasks/task_e_68a649a2ff888333957a5e6332074834