### PR TITLE
Add psycopg dependency for Celery healthcheck

### DIFF
--- a/services/etl/requirements.txt
+++ b/services/etl/requirements.txt
@@ -8,4 +8,5 @@ numpy<2
 pandas==2.2.*
 pandera==0.19.*
 openpyxl==3.1.*
+psycopg[binary]==3.2.9
 psycopg2-binary==2.9.*


### PR DESCRIPTION
## Summary
- install psycopg v3 for the worker image so the Celery healthcheck can import it

## Root Cause
- `services/ingest/healthcheck.py` imports `psycopg`, but the worker image was only installing `psycopg2-binary`.  The missing dependency caused the healthcheck process to error out, leaving `celery_worker-1` unhealthy and failing the compose health checks.

## Fix
- add `psycopg[binary]==3.2.9` to `services/etl/requirements.txt` so the worker container has the correct library

## Repro Steps
- `docker compose up -d --wait` (from CI logs `ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt`)

## Risks
- Installing both psycopg v3 and psycopg2 increases image size slightly, but keeps existing code using psycopg2 working.

## Links
- ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt


------
https://chatgpt.com/codex/tasks/task_e_68a652a933b48333b3faf5dbc20d4aab