### PR TITLE
Fix ETL healthcheck packaging and timeout

### DIFF
--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -14,3 +14,20 @@ Docker compose health checks failed because the Redis service exited immediately
 - `ci-logs/latest/CI/compose-health/6_Run export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1.txt`
 - `ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt`
 
+---
+
+## Failing workflows
+- **test** workflow (health-checks job)
+
+## Summary
+`docker compose` reported `container awa-app-etl-1 is unhealthy`. The ETL image lacked the
+`services.common` package and used an invalid `timeout` parameter in the healthcheck,
+causing the script to crash.
+
+## Fix
+- Include the `services` package in the ETL image and set `PYTHONPATH`.
+- Use `connect_timeout` when opening the database connection in `healthcheck.py`.
+
+## Logs
+- `ci-logs/latest/test/2_health-checks.txt`
+

--- a/services/etl/Dockerfile
+++ b/services/etl/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.6
 FROM python:3.12-slim AS base
 ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app:/app/services
 WORKDIR /app
 COPY services/etl/requirements*.txt services/etl/constraints.txt ./
 ARG CONSTRAINTS=""
@@ -9,12 +10,16 @@ RUN if [ -n "$CONSTRAINTS" ] && [ -f "$CONSTRAINTS" ]; then \
     else \
         pip install -r requirements.txt; \
     fi
-COPY services/etl/ .
+# copy shared modules under /app/services
+COPY services/common/ ./services/common
+COPY services/etl/ ./services/etl
+RUN chmod +x services/etl/wait-for-it.sh services/etl/entrypoint.sh
 
 FROM python:3.12-slim
 ARG TZ_CACHE_BUST
 ENV PYTHONUNBUFFERED=1
-WORKDIR /app
+ENV PYTHONPATH=/app:/app/services
+WORKDIR /app/services/etl
 COPY --from=base /usr/local /usr/local
 COPY --from=base /app /app
 ARG DEBIAN_FRONTEND=noninteractive
@@ -26,9 +31,6 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends tzdata; \
     rm -rf /var/lib/apt/lists/*
 ENV TZ=UTC
-COPY services/etl/wait-for-it.sh /usr/local/bin/wait-for-it.sh
-RUN chmod +x /usr/local/bin/wait-for-it.sh
-COPY services/etl/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
-HEALTHCHECK CMD ["true"]
+ENTRYPOINT ["/bin/bash", "./entrypoint.sh"]
+# default to running the in-tree healthcheck; docker-compose may override
+HEALTHCHECK CMD ["python", "-m", "services.etl.healthcheck"]

--- a/services/etl/healthcheck.py
+++ b/services/etl/healthcheck.py
@@ -11,7 +11,10 @@ from services.common.dsn import build_dsn
 
 def check_db() -> None:
     dsn = build_dsn(sync=True).replace("+psycopg", "")
-    with psycopg.connect(dsn, timeout=2) as conn:
+    # ``psycopg.connect`` expects ``connect_timeout`` instead of ``timeout``.
+    # Using the wrong parameter causes "invalid connection option" errors and
+    # makes the container healthcheck fail.
+    with psycopg.connect(dsn, connect_timeout=2) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT 1")
 


### PR DESCRIPTION
## Summary
- ensure ETL container includes shared modules and has correct PYTHONPATH
- use `connect_timeout` in ETL healthcheck to avoid invalid option errors
- record CI investigation details

## Root cause
The `test` workflow's health-checks job failed because the `etl` service healthcheck crashed. The ETL image only copied `services/etl` files, so `python -m services.etl.healthcheck` could not import `services.common`. Additionally, the healthcheck used `timeout` with `psycopg.connect`, which psycopg treats as an invalid connection option, causing the script to exit non-zero. These errors left the container reported as unhealthy and the job failed.

## Fix
- Copy `services/common` into the ETL image and set `PYTHONPATH`
- Run the container from `/app/services/etl` and use module-based entrypoint
- Replace `timeout` with `connect_timeout` in `services/etl/healthcheck.py`
- Document the failure in `docs/ci-triage.md`

## Repro steps
- `python -m services.etl.healthcheck` (fails with connection refused if DB unavailable)
- (CI) `docker compose up -d --wait && docker compose ps --format '{{.Name}} {{.State}} {{.Health}}'`

## Risk
- Minimal: updates ETL Docker build and healthcheck; affects only container build but adds shared code. Image size slightly larger.

## Links
- `ci-logs/latest/test/2_health-checks.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a659df559c83338dd6c6e78ede773e