### PR TITLE
fix: correct psycopg timeout in healthcheck

### DIFF
--- a/services/ingest/healthcheck.py
+++ b/services/ingest/healthcheck.py
@@ -14,7 +14,7 @@ from .celery_app import celery_app
 
 def check_db() -> None:
     dsn = build_dsn(sync=True).replace("+psycopg", "")
-    with psycopg.connect(dsn, timeout=2) as conn:
+    with psycopg.connect(dsn, connect_timeout=2) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT 1")
 


### PR DESCRIPTION
## Summary
- fix celery worker healthcheck by using psycopg's connect_timeout parameter

## Root Cause
- `services/ingest/healthcheck.py` used `timeout` when opening a database connection, causing the check to error and the `celery_worker` container to be marked unhealthy

## Fix
- replace `timeout` with `connect_timeout` when calling `psycopg.connect`

## Repro Steps
- `python -m services.ingest.healthcheck worker`
- `pre-commit run --files services/ingest/healthcheck.py` *(fails: requires GitHub credentials)*

## Risk
- Low: only affects the internal health check; correct parameter is backward compatible

## Links
- ci-logs/latest/test/0_health-checks.txt


------
https://chatgpt.com/codex/tasks/task_e_68a668232020833387704ca8a485724a