### PR TITLE
fix: export pg vars for migrations

### DIFF
--- a/services/api/entrypoint.sh
+++ b/services/api/entrypoint.sh
@@ -7,6 +7,9 @@
 : "${PG_PASSWORD:=pass}"
 : "${PG_DATABASE:=awa}"
 
+# ensure these variables are available to subprocesses such as alembic
+export PG_HOST PG_PORT PG_USER PG_PASSWORD PG_DATABASE
+
 set -euo pipefail
 
 # If the first argument looks like a command, run it directly.


### PR DESCRIPTION
## Summary
- export Postgres env vars in API entrypoint so alembic has access

## Root Cause
- compose-health job showed the `api` container exiting during startup, failing migrations due to missing `PG_*` variables

## Fix
- export `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, and `PG_DATABASE` in `services/api/entrypoint.sh`

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait --no-build --pull always`

## Risk
- Low: only affects environment variable propagation for migrations

## Links
- ci-logs/latest/CI/3_compose-health.txt


------
https://chatgpt.com/codex/tasks/task_e_68a6cbe1f8788333a734e255a3dcada3