### PR TITLE
fix: allow custom entrypoint command

### DIFF
--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -31,3 +31,17 @@ causing the script to crash.
 ## Logs
 - `ci-logs/latest/test/2_health-checks.txt`
 
+---
+
+## Failing workflows
+- **test** workflow (health-checks job)
+
+## Summary
+`docker compose` reported `container awa-app-celery_worker-1 is unhealthy` because the ETL entrypoint always executed `keepa_ingestor.py`, ignoring the Celery command so the worker never started.
+
+## Fix
+- Allow `services/etl/entrypoint.sh` to execute the provided command after waiting for PostgreSQL, falling back to `keepa_ingestor.py` when none is supplied.
+
+## Logs
+- `ci-logs/latest/test/0_health-checks.txt`
+- `ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt`

--- a/services/etl/entrypoint.sh
+++ b/services/etl/entrypoint.sh
@@ -2,4 +2,11 @@
 set -euo pipefail
 
 : "${PG_HOST:=postgres}"
-./wait-for-it.sh --timeout=30 "$PG_HOST:5432" -- python keepa_ingestor.py
+
+./wait-for-it.sh --timeout=30 "$PG_HOST:5432"
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+else
+  exec python keepa_ingestor.py
+fi


### PR DESCRIPTION
## Summary
- let ETL entrypoint forward container commands so celery worker can start

## Root Cause
- health-check job reported `container awa-app-celery_worker-1 is unhealthy`
- ETL entrypoint always executed `keepa_ingestor.py`, ignoring the command to run the celery worker

## Fix
- execute provided command after waiting for PostgreSQL, falling back to `keepa_ingestor.py` when no command is supplied

## Repro Steps
- `docker compose up -d --wait` (from logs)

## Risk
- Low: entrypoint continues to run the original script when no command is given, preserving existing behaviour.

## Links
- `ci-logs/latest/test/0_health-checks.txt`
- `ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a6d592f7648333acb4e4e788a4b572