### PR TITLE
ci: use postgres host for compose health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,8 @@ jobs:
       - name: Load env
         run: |
           cat .env.ci >> "$GITHUB_ENV"
-          echo "DATABASE_URL=postgresql+asyncpg://postgres:pass@localhost:5432/awa" >> "$GITHUB_ENV"
-          echo "PG_HOST=localhost" >> "$GITHUB_ENV"
+          echo "DATABASE_URL=postgresql+asyncpg://postgres:pass@postgres:5432/awa" >> "$GITHUB_ENV"
+          echo "PG_HOST=postgres" >> "$GITHUB_ENV"
           echo "PG_PORT=5432" >> "$GITHUB_ENV"
           echo "PG_USER=postgres" >> "$GITHUB_ENV"
           echo "PG_PASSWORD=pass" >> "$GITHUB_ENV"

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -45,3 +45,17 @@ causing the script to crash.
 ## Logs
 - `ci-logs/latest/test/0_health-checks.txt`
 - `ci-logs/latest/test/health-checks/5_Run export COMPOSE_DOCKER_CLI_BUILD=1.txt`
+
+---
+
+## Failing workflows
+- **CI** workflow (compose-health job)
+
+## Summary
+The API container failed its health check because it was configured to reach PostgreSQL at `localhost`, which is inaccessible from within the container network.
+
+## Fix
+- Use the `postgres` service hostname for `DATABASE_URL` and `PG_HOST` in the compose-health job.
+
+## Logs
+- `ci-logs/latest/CI/3_compose-health.txt`


### PR DESCRIPTION
## Summary
- fix compose-health job by pointing DB env vars to the postgres service
- document API compose-health failure in CI triage

## Root Cause
- The compose-health job set `DATABASE_URL` and `PG_HOST` to `localhost`, so the API container tried to reach PostgreSQL on the loopback interface and exited before health checks completed.

## Fix
- Use the `postgres` hostname for `DATABASE_URL` and `PG_HOST` in the compose-health job.
- Add entry to `docs/ci-triage.md` describing the failure.

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait --no-build --pull always`

## Risk
- Low: only affects CI compose health check environment variables.

## Links
- `ci-logs/latest/CI/3_compose-health.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a6e2153c3c8333ba2ff4cd4809d4eb