### PR TITLE
Increase service startup wait

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -148,7 +148,7 @@ async def _wait_for_db() -> None:
     url = build_dsn(sync=True)
 
     delay = 0.2
-    for _ in range(10):
+    for _ in range(50):
         try:
             engine = create_engine(url)
             with engine.connect() as conn:
@@ -162,7 +162,7 @@ async def _wait_for_db() -> None:
 
 async def _wait_for_redis(url: str) -> aioredis.Redis:
     delay = 0.2
-    for _ in range(10):
+    for _ in range(50):
         try:
             r = aioredis.from_url(url, encoding="utf-8", decode_responses=True)
             await r.ping()


### PR DESCRIPTION
## Summary
- extend DB and Redis wait loops to allow service containers more time to come online during tests

## Root Cause
- `_wait_for_redis` and `_wait_for_db` only retried for ~2s, so tests failed with `RuntimeError: Redis not available` when services were slow to start

## Fix
- bump retry loops from 10 to 50 in `_wait_for_db`
- bump retry loops from 10 to 50 in `_wait_for_redis`

## Repro Steps
- `REDIS_URL=redis://redis:6379/0 pytest tests/test_health.py::test_health[0] -q` (fails)
- start redis and set `REDIS_URL=redis://localhost:6379/0`
- `pytest tests/test_health.py::test_health[0] -q` (passes)

## Risk
- Slightly longer startup if DB/Redis truly unavailable

## Links
- ci-logs/latest/test/0_integration-db.txt

------
https://chatgpt.com/codex/tasks/task_e_68a742cd437883338c7f57854bb4c21e