### PR TITLE
Include DB host details for compose health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ x-database-env: &db-env
   PG_SYNC_DSN: ${PG_SYNC_DSN}
   PG_ASYNC_DSN: ${PG_ASYNC_DSN}
   DATABASE_URL: ${DATABASE_URL}
+  PG_HOST: ${PG_HOST}
+  PG_PORT: ${PG_PORT}
 
 services:
   postgres:

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -89,3 +89,19 @@ report ready.
 
 ## Logs
 - `ci-logs/latest/CI/install-deps.txt`
+
+---
+
+## Failing workflows
+- **CI** workflow (compose-health job)
+- **test** workflow (health-checks job)
+
+## Summary
+`docker compose` reported `container awa-app-celery_worker-1 is unhealthy` and `container awa-app-etl-1 is unhealthy`. The healthcheck scripts built a DSN that still pointed to `localhost`, preventing services from reaching the PostgreSQL container.
+
+## Fix
+- Expose `PG_HOST` and `PG_PORT` to services in `docker-compose.yml` so the DSN resolves to the `postgres` service.
+
+## Logs
+- `ci-logs/latest/CI/3_compose-health.txt`
+- `ci-logs/latest/test/2_health-checks.txt`


### PR DESCRIPTION
## Summary
- ensure service containers receive database host and port
- document CI fix in triage notes

## Root Cause
- The compose health checks used DSNs targeting `localhost`, which isn't accessible from other containers, leaving `celery_worker` and `etl` unhealthy.

## Fix
- Add `PG_HOST` and `PG_PORT` to the shared compose environment so DSNs resolve to the Postgres service
- Record the investigation and resolution in `docs/ci-triage.md`

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait --no-build --pull always`
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml down -v --remove-orphans`

## Risks
- If `PG_HOST`/`PG_PORT` are absent the variables expand to empty strings, but the DSN remains unchanged, so impact is low.

## Links
- `ci-logs/latest/CI/3_compose-health.txt`
- `ci-logs/latest/test/2_health-checks.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a764b0d3b08333b55c975e7567fdaa