### PR TITLE
fix: merge Alembic heads

### DIFF
--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -105,3 +105,18 @@ report ready.
 ## Logs
 - `ci-logs/latest/CI/3_compose-health.txt`
 - `ci-logs/latest/test/2_health-checks.txt`
+---
+
+## Failing workflows
+- **CI** workflow (unit job)
+- **test** workflow (test job)
+
+## Summary
+`alembic upgrade head` failed because two migrations shared the same parent revision, producing multiple heads (`0026_amazon_new_reports` and `0026_fix_refund_views`).
+
+## Fix
+- Add a merge migration `0027_merge_reports_and_refund_heads` to unify the heads.
+
+## Logs
+- `ci-logs/latest/CI/unit/10_Run migrations.txt`
+- `ci-logs/latest/test/test/13_Run Alembic migrations.txt`

--- a/services/api/migrations/versions/0027_merge_reports_and_refund_heads.py
+++ b/services/api/migrations/versions/0027_merge_reports_and_refund_heads.py
@@ -1,0 +1,12 @@
+revision = "0027_merge_reports_and_refund_heads"
+down_revision = ("0026_amazon_new_reports", "0026_fix_refund_views")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
Resolves failing migrations by merging divergent Alembic heads.

## Root cause
Two migrations (`0026_amazon_new_reports` and `0026_fix_refund_views`) shared the same parent revision, leaving multiple heads. `alembic upgrade head` aborted with “Multiple head revisions are present for given argument 'head'”.

## Fix
- Add merge revision `0027_merge_reports_and_refund_heads` combining both heads.
- Document the failure and resolution in `docs/ci-triage.md`.

## Repro steps
- `PYTHONPATH=. alembic -c services/api/alembic.ini heads`

## Risk
Low. The merge revision contains no schema changes and only reconciles migration history.

## Links
- `ci-logs/latest/CI/unit/10_Run migrations.txt`
- `ci-logs/latest/test/test/13_Run Alembic migrations.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a7884774248333b0f6ca4e91176076