### PR TITLE
fix: shorten migration revision id

### DIFF
--- a/services/api/migrations/versions/0027_merge_reports_refund_heads.py
+++ b/services/api/migrations/versions/0027_merge_reports_refund_heads.py
@@ -1,4 +1,4 @@
-revision = "0027_merge_reports_and_refund_heads"
+revision = "0027_merge_reports_refund_heads"
 down_revision = ("0026_amazon_new_reports", "0026_fix_refund_views")
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- shorten Alembic revision id to fit alembic_version column

## Root Cause
- Alembic migration `0027_merge_reports_and_refund_heads` had a revision id longer than the `alembic_version.version_num` column, causing `value too long` errors during migrations

## Fix
- rename migration file and trim revision id to `0027_merge_reports_refund_heads`

## Repro Steps
- `pip install -r requirements-dev.txt`
- `pip install keepa==1.3.15 minio==7.1.15`
- `alembic -c services/api/alembic.ini upgrade head`

## Risk
- Low: existing databases may need the revised revision id applied, but migration logic is unchanged

## Links
- `ci-logs/latest/CI/unit/10_Run migrations.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a78c58f2f0833392b657f9ece55ef7