### PR TITLE
fix: add sys path for migrations

### DIFF
--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -120,3 +120,16 @@ report ready.
 ## Logs
 - `ci-logs/latest/CI/unit/10_Run migrations.txt`
 - `ci-logs/latest/test/test/13_Run Alembic migrations.txt`
+---
+
+## Failing workflows
+- **CI** workflow (migrations-check job)
+
+## Summary
+`alembic heads` failed with `ModuleNotFoundError: No module named 'services'` while loading migration `0023_add_storage_fee.py`. The revision imported project utilities without ensuring the repository root was on `sys.path`.
+
+## Fix
+- Append the repository root to `sys.path` in migrations before importing project modules.
+
+## Logs
+- `ci-logs/latest/CI/1_migrations-check.txt`

--- a/services/api/migrations/versions/0023_add_storage_fee.py
+++ b/services/api/migrations/versions/0023_add_storage_fee.py
@@ -1,9 +1,13 @@
 from textwrap import dedent
+import sys
+from pathlib import Path
 
 import sqlalchemy as sa
 from sqlalchemy import inspect
 
 from alembic import op  # type: ignore[attr-defined]
+
+sys.path.append(str(Path(__file__).resolve().parents[4]))
 from services.db.utils.views import replace_view
 
 revision = "0023_add_storage_fee"

--- a/services/api/migrations/versions/0026_fix_refund_views.py
+++ b/services/api/migrations/versions/0026_fix_refund_views.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+import sys
 from textwrap import dedent
 
 from alembic import op
+
+sys.path.append(str(Path(__file__).resolve().parents[4]))
 from services.db.utils.views import replace_view
 
 revision = "0026_fix_refund_views"


### PR DESCRIPTION
## Summary
- ensure migration scripts can import project utilities without ModuleNotFoundError
- document CI migration check failure

## Root Cause
- Alembic's `heads` command loads migration scripts without executing `env.py`, leaving the repository root off `sys.path`. Revisions 0023 and 0026 imported `services.db.utils.views` directly, causing `ModuleNotFoundError`.

## Fix
- append repository root to `sys.path` before importing project modules in migrations `0023_add_storage_fee` and `0026_fix_refund_views`
- record the CI failure and resolution in `docs/ci-triage.md`

## Repro Steps
- `alembic -c services/api/alembic.ini heads`
- `pytest tests/test_replace_view.py -q -o addopts=""`

## Risk
- Low: only affects migration scripts during CI checks.

## Links
- ci-logs/latest/CI/1_migrations-check.txt


------
https://chatgpt.com/codex/tasks/task_e_68a7928355b48333ae614444a4e0417f