### PR TITLE
fix: use async dsn for api

### DIFF
--- a/services/api/db.py
+++ b/services/api/db.py
@@ -6,7 +6,9 @@ from sqlalchemy.pool import NullPool
 
 from services.common.dsn import build_dsn
 
-DATABASE_URL = os.getenv("DATABASE_URL") or build_dsn(sync=False)
+# Always derive the database URL via build_dsn so it uses the async driver
+# even if a synchronous DATABASE_URL is provided in the environment.
+DATABASE_URL = build_dsn(sync=False)
 
 pool_kwargs = {}
 if os.getenv("TESTING") == "1":


### PR DESCRIPTION
## Summary
- ensure API service always uses an async Postgres DSN

## Root Cause
- `services/api/db.py` read `DATABASE_URL` directly which contained a synchronous driver (`psycopg2`) in the compose environment, causing the API container to exit during startup.

## Fix
- always build the DSN via `build_dsn(sync=False)` so the async driver is selected even when `DATABASE_URL` is set

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up api`

## Risk
- Low: only changes how the database URL is derived; uses existing utility used across the project.

## Links
- ci-logs/latest/test/0_health-checks.txt


------
https://chatgpt.com/codex/tasks/task_e_68a8d0053e8c8333a519ddc437f5af45