### PR TITLE
Ensure Postgres env vars for compose health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
           echo "PG_USER=postgres" >> "$GITHUB_ENV"
           echo "PG_PASSWORD=pass" >> "$GITHUB_ENV"
           echo "PG_DATABASE=awa" >> "$GITHUB_ENV"
+          echo "POSTGRES_USER=postgres" >> "$GITHUB_ENV"
+          echo "POSTGRES_PASSWORD=pass" >> "$GITHUB_ENV"
+          echo "POSTGRES_DB=awa" >> "$GITHUB_ENV"
       - run: |
           export COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1
           docker compose --progress=plain \


### PR DESCRIPTION
## Summary
- define `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` in the compose health job so docker-compose config receives the expected values

## Root Cause
- The compose health workflow only exported `PG_*` variables; `POSTGRES_*` variables were left undefined. Docker Compose substituted them as empty strings, so Postgres started without the intended database and the API container exited early because it could not reach the database, causing `docker compose` to fail.

## Testing
- `pytest tests/test_health.py::test_health -q` *(fails: Redis not available; environment lacks Redis service)*


------
https://chatgpt.com/codex/tasks/task_e_68a8e15597ec8333bfb012867c61cb58