### PR TITLE
fix: restore API healthcheck in CI compose

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,6 +9,7 @@ services:
     profiles: ["ci-skip"]
   api:
     healthcheck:
+      test: ["CMD", "curl", "-fsSL", "http://localhost:8000/health"]
       start_period: 30s
       interval: 5s
       timeout: 3s


### PR DESCRIPTION
## Summary
- ensure CI compose uses proper health check for API service

## Root Cause
- `docker-compose.ci.yml` overwrote the API healthcheck without a `test` command, leaving the container without a health probe. `docker compose up --wait` treated the service as failed and stopped the workflow, as seen when the API container exited early in the health check run.

## Fix
- add the missing `curl` test command to the API service's healthcheck in `docker-compose.ci.yml`

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait --no-build --pull always`

## Risk
- Low. The change only restores the health check command used in other environments and does not alter application code.

## Links
- ci-logs/latest/test/2_health-checks.txt


------
https://chatgpt.com/codex/tasks/task_e_68a8fcaca5588333b1e2d8d7b393208e