### PR TITLE
Fix compose-health DB DSN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
           echo "PG_USER=postgres" >> "$GITHUB_ENV"
           echo "PG_PASSWORD=pass" >> "$GITHUB_ENV"
           echo "PG_DATABASE=awa" >> "$GITHUB_ENV"
+          echo "PG_SYNC_DSN=postgresql+psycopg://postgres:pass@postgres:5432/awa" >> "$GITHUB_ENV"
+          echo "PG_ASYNC_DSN=postgresql+asyncpg://postgres:pass@postgres:5432/awa" >> "$GITHUB_ENV"
           echo "POSTGRES_USER=postgres" >> "$GITHUB_ENV"
           echo "POSTGRES_PASSWORD=pass" >> "$GITHUB_ENV"
           echo "POSTGRES_DB=awa" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- ensure compose-health job sets Postgres DSNs to the container host

## Root Cause
- compose-health workflow only overrides `PG_HOST` but left `PG_SYNC_DSN`/`PG_ASYNC_DSN` pointing at localhost, leading the API container to fail to reach the database and exit early.

## Fix
- override `PG_SYNC_DSN` and `PG_ASYNC_DSN` in `.github/workflows/ci.yml` with DSNs that point to the `postgres` service

## Repro Steps
- Trigger `compose-health` job in CI on `main` before this change
- Observe `container awa-app-api-1 exited (1)`

## Risk
- Low: change only affects CI workflow environment variables


------
https://chatgpt.com/codex/tasks/task_e_68a9a50ead0c833388e7701858de9053