### PR TITLE
Handle missing request client in API rate limiter

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -47,7 +47,10 @@ async def client_ip_identifier(request: Request) -> str:
         xri = request.headers.get("x-real-ip")
         if xri:
             return xri.strip()
-    return request.client.host or "unknown"
+    client = request.client
+    if not client or not getattr(client, "host", None):
+        return "unknown"
+    return client.host
 
 
 def _parse_rate_limit(s: str) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- avoid crashes when request lacks client info by checking for `request.client` in IP identifier

## Root Cause
- `client_ip_identifier` assumed `request.client` was always available; when health checks sent requests without client metadata, the API raised an exception and the container exited【ci-logs/latest/test/2_health-checks.txt†L2170-L2202】

## Fix
- guard against missing `request.client` before accessing its host【F:services/api/main.py†L40-L53】

## Repro Steps
- `pytest`

## Risk
- Low: only adds a null check for optional request client information

## Links
- ci-logs/latest/test/2_health-checks.txt

------
https://chatgpt.com/codex/tasks/task_e_68a9acdced9083338e2f3b93b692ca5f