### PR TITLE
Fix missing PG vars in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ x-database-env: &db-env
   DATABASE_URL: ${DATABASE_URL}
   PG_HOST: ${PG_HOST}
   PG_PORT: ${PG_PORT}
+  PG_USER: ${PG_USER}
+  PG_PASSWORD: ${PG_PASSWORD}
+  PG_DATABASE: ${PG_DATABASE}
 
 services:
   postgres:


### PR DESCRIPTION
## Summary
- Ensure all services receive required PostgreSQL credentials

## Root Cause
- `docker-compose.yml` omitted `PG_USER`, `PG_PASSWORD` and `PG_DATABASE` so the API container crashed during startup when building its DSN

## Fix
- Pass `PG_USER`, `PG_PASSWORD` and `PG_DATABASE` via the shared `x-database-env` block

## Repro Steps
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.postgres.yml up -d --wait --no-build --pull always`

## Risk
- Low: only adds missing environment variables for database connectivity

## Links
- ci-logs/latest/test/0_health-checks.txt


------
https://chatgpt.com/codex/tasks/task_e_68a9bcd244248333b968f2379a755a8e