### PR TITLE
Fix Postgres readiness check in API startup

### DIFF
--- a/services/api/docker-entrypoint.sh
+++ b/services/api/docker-entrypoint.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-until pg_isready -h postgres -p 5432 -U postgres; do
+# Ensure pg_isready authenticates using the same credentials as the app
+export PGPASSWORD="${PG_PASSWORD:-}"
+
+until pg_isready \
+  -h "${PG_HOST:-postgres}" \
+  -p "${PG_PORT:-5432}" \
+  -U "${PG_USER:-postgres}" \
+  -d "${PG_DATABASE:-postgres}"; do
   echo "Postgres not ready – waiting"
   sleep 1
 done


### PR DESCRIPTION
## Summary
- ensure API container waits for Postgres using correct credentials

## Root Cause
- `services/api/docker-entrypoint.sh` checked Postgres readiness without passing authentication or DB details causing `pg_isready` to fail and the API container to exit during CI health checks.

## Fix
- export `PGPASSWORD` from existing env vars before `pg_isready`
- use `PG_HOST`, `PG_PORT`, `PG_USER`, and `PG_DATABASE` when invoking `pg_isready`

## Repro Steps
- `docker compose up api` (previously exited immediately with pg_isready auth failure)

## Risks
- minimal; affects startup script only and uses existing env vars

## Links
- ci-logs/latest/test/1_health-checks.txt

------
https://chatgpt.com/codex/tasks/task_e_68a9c863291c8333b26177b33751eed0