### PR TITLE
Fix ci-logs workflow: per-workflow folders and compose-e2e artifacts

### DIFF
--- a/.github/workflows/ci-logs.yml
+++ b/.github/workflows/ci-logs.yml
@@ -1,7 +1,7 @@
 name: ci-logs
 on:
   workflow_run:
-    workflows: ["CI", "compose-e2e", "test"]  # include your main workflows
+    workflows: ["CI", "compose-e2e", "test"]
     types: [completed]
 
 permissions:
@@ -10,101 +10,79 @@ permissions:
 
 jobs:
   collect-and-commit:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
+    # do nothing if this is our own logs workflow
+    if: ${{ github.event.workflow_run.name != 'ci-logs' }}
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout target repo at the triggering SHA (or main)
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch || 'main' }}
           fetch-depth: 0
 
+      - name: Determine target directory
+        id: vars
+        run: |
+          WF_NAME="${{ github.event.workflow_run.name }}"
+          echo "wf_dir=ci-logs/latest/${WF_NAME}" >> $GITHUB_OUTPUT
+
       - name: Prepare directories
         run: |
           set -Eeuo pipefail
-          mkdir -p ci-logs/latest/CI
-          mkdir -p ci-logs/latest/CI/unit
-          mkdir -p ci-logs/latest/CI/migrations-check
-          mkdir -p ci-logs/latest/CI/compose-health
-          mkdir -p ci-logs/latest/test
-          mkdir -p ci-logs/latest/Docs/publish
+          mkdir -p "${{ steps.vars.outputs.wf_dir }}"
 
-      # Option A: download artifacts produced by the main workflows (preferred)
       - name: Download artifacts from triggering workflow
         uses: actions/download-artifact@v4
         with:
-          # If you name artifacts in CI jobs ("coverage", "docker-logs", etc.), list them here
           pattern: '*'
-          path: ci-logs/latest/_artifacts
+          path: "${{ steps.vars.outputs.wf_dir }}/artifacts"
         continue-on-error: true
 
-      # Option B: re-run summary commands to reconstruct logs (fallback)
-      # (only if your CI didn't upload artifacts)
-      - name: Reconstruct minimal logs (fallback)
+      - name: Write minimal run summary if no artifacts
         run: |
-          echo "Run ID: ${{ github.event.workflow_run.id }}" > ci-logs/latest/CI/0_run.txt
-          echo "Conclusion: ${{ github.event.workflow_run.conclusion }}" >> ci-logs/latest/CI/0_run.txt
-          # Add any API calls or GH CLI summary if needed
-        shell: bash
+          printf "Run ID: %s\nConclusion: %s\n" \
+            "${{ github.event.workflow_run.id }}" \
+            "${{ github.event.workflow_run.conclusion }}" \
+            > "${{ steps.vars.outputs.wf_dir }}/run.txt"
         continue-on-error: true
 
-      - name: Normalize filenames for git (no NUL/CRLF)
+      - name: Write index for this run
         run: |
-          set -Eeuo pipefail
-          find ci-logs/latest -type f -print0 | xargs -0 -I{} bash -lc 'iconv -f UTF-8 -t UTF-8 "{}" -o "{}" || true'
-
-      - name: Write triage index
-        run: |
-          set -Eeuo pipefail
           {
-            echo "# Latest CI logs"
+            echo "# Logs for workflow: ${{ github.event.workflow_run.name }}"
             echo ""
             echo "- Run: ${{ github.event.workflow_run.id }}"
-            echo "- Workflow: ${{ github.event.workflow_run.name }}"
             echo "- Conclusion: ${{ github.event.workflow_run.conclusion }}"
+            echo "- Branch: ${{ github.event.workflow_run.head_branch }}"
             echo "- SHA: ${{ github.event.workflow_run.head_sha }}"
             echo ""
-            echo "## Folders"
-            find ci-logs/latest -maxdepth 2 -type d | sed 's#^#- #'
-            echo ""
-            echo "## Files"
-            find ci-logs/latest -type f | sed 's#^#- #'
-          } > ci-logs/latest/README.md
+            echo "## Contents"
+            find "${{ steps.vars.outputs.wf_dir }}" -type f | sed 's#^#- #'
+          } > "${{ steps.vars.outputs.wf_dir }}/README.md"
 
-      - name: Git commit logs tree
+      - name: Commit logs
         env:
           GH_USER_NAME: "ci-logs-bot"
           GH_USER_EMAIL: "ci-logs-bot@users.noreply.github.com"
         run: |
           set -Eeuo pipefail
-          git config user.name  "${GH_USER_NAME}"
-          git config user.email "${GH_USER_EMAIL}"
-
-          # Choose strategy:
-          # 1) Commit to a dedicated branch/PR (recommended)
+          git config user.name  "$GH_USER_NAME"
+          git config user.email "$GH_USER_EMAIL"
           BR="ci-logs/${{ github.run_id }}"
           git checkout -B "$BR"
-
-          # Avoid huge diffs by resetting previous latest logs (optional):
-          # rm -rf ci-logs/latest/*
-
           git add -A ci-logs/latest
           if git diff --cached --quiet; then
             echo "No log changes to commit."
             exit 0
           fi
-          git commit -m "ci-logs: update latest logs for run ${{ github.event.workflow_run.id }}"
-
-          # push and open/update PR
+          git commit -m "ci-logs: update logs for ${{ github.event.workflow_run.name }} run ${{ github.event.workflow_run.id }}"
           git push -f origin "$BR"
 
       - name: Open or update PR for logs
         uses: peter-evans/create-pull-request@v6
         with:
           branch: ci-logs/${{ github.run_id }}
-          title: "ci-logs: update latest logs (run ${{ github.run_id }})"
-          body: "Automated logs update from workflow_run `${{ github.event.workflow_run.name }}`"
+          title: "ci-logs: update logs for ${{ github.event.workflow_run.name }} (run ${{ github.run_id }})"
+          body: "Automated logs update from workflow_run `${{ github.event.workflow_run.name }}`."
           commit-message: "ci-logs: update"
           labels: ci-logs
           base: ${{ github.event.workflow_run.head_branch || 'main' }}

--- a/.github/workflows/compose-e2e.yml
+++ b/.github/workflows/compose-e2e.yml
@@ -2,7 +2,10 @@ name: compose-e2e
 on:
   push:
     branches: [dev, main]
+    paths-ignore: ['ci-logs/**']
   pull_request:
+    branches: [dev, main]
+    paths-ignore: ['ci-logs/**']
 
 jobs:
   compose-e2e:
@@ -56,6 +59,19 @@ jobs:
             echo "::endgroup::"
             exit 1
           fi
+
+      - name: Collect docker logs on failure
+        if: failure()
+        run: docker compose --env-file .env.ci logs --no-color --since=30m > compose-logs.txt || true
+
+      - name: Upload compose-e2e logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-e2e-logs
+          path: |
+            ps.txt
+            compose-logs.txt
+        if: always()
 
       - name: Tear down (always)
         if: always()


### PR DESCRIPTION
## Summary
- isolate ci logs per workflow and skip self-triggering runs
- capture compose-e2e ps/docker logs and ignore ci-logs branches

## Root Cause
- ci-logs workflow wrote to fixed directories and could reprocess itself
- compose-e2e missed log artifacts and triggered on ci-logs branches

## Fix
- compute `ci-logs/latest/${workflow}` and download artifacts into it
- commit updated log tree on branch `ci-logs/<run_id>` and open PR
- add `paths-ignore: ['ci-logs/**']` to compose-e2e triggers
- upload compose-e2e `ps.txt` and docker logs as artifacts

## Repro Steps
- `pre-commit run --files .github/workflows/ci-logs.yml .github/workflows/compose-e2e.yml`

## Risk
- Low: adjustments affect only CI workflows and log collection

## Links
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68ab8a311d008333afbff221c1d0b135