### PR TITLE
Fix logs-after-ci workflow conditional syntax

### DIFF
--- a/.github/workflows/logs-after-ci.yml
+++ b/.github/workflows/logs-after-ci.yml
@@ -15,10 +15,10 @@ concurrency:
 jobs:
   gather-and-commit:
     # Only run on PRs and merges to main; skip if triggered by other refs
+    # Do not run on our own commits (in case the workflow_run name is logs-after-ci)
     if: >
       (github.event.workflow_run.event == 'pull_request')
       || (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main')
-    # Do not run on our own commits (in case the workflow_run name is logs-after-ci)
       && github.event.workflow_run.name != 'logs-after-ci'
     runs-on: ubuntu-latest
 

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -194,3 +194,17 @@ healthcheck scripts now retry failed probes, which can take longer than the
 
 ## Logs
 - `ci-logs/latest/CI/3_compose-health.txt`
+
+---
+
+## Failing workflows
+- **logs-after-ci** workflow (gather-and-commit job)
+
+## Summary
+GitHub Actions reported `Invalid workflow file` because line 22 in `.github/workflows/logs-after-ci.yml` was outside the multi-line `if` block, leaving an orphaned `&&` expression.
+
+## Fix
+- Move the explanatory comment above the `if` block so the entire condition remains within the YAML scalar.
+
+## Logs
+- No log file was generated; the workflow failed before execution.


### PR DESCRIPTION
## Summary
Fix `logs-after-ci` workflow syntax so GitHub Actions can load it.

## Root cause
`logs-after-ci.yml` placed a comment between lines of a folded `if` condition, closing the block early and leaving an orphaned `&&` expression on line 22, which GitHub flagged as invalid.

## Fix
- Move the explanatory comment above the multi-line `if` block so all condition lines stay together.
- Add a CI triage note explaining the YAML syntax error.

## Repro steps
- `pre-commit run --files .github/workflows/logs-after-ci.yml`

## Risk
Low. The change only affects the `logs-after-ci` workflow's conditional and documentation.

## Links
- `docs/ci-triage.md`


------
https://chatgpt.com/codex/tasks/task_e_68ab90a1e22483339029def0571fddc9