### PR TITLE
Fix collect-logs wait step indentation

### DIFF
--- a/.github/workflows/collect-logs.yml
+++ b/.github/workflows/collect-logs.yml
@@ -56,21 +56,25 @@ jobs:
           "X-GitHub-Api-Version": "2022-11-28",
           "User-Agent": "gha-log-collector"}
           def api(path, params=None):
-          url="https://api.github.com/"+path
-          if params: url += "?"+urllib.parse.urlencode(params)
-          req=urllib.request.Request(url, headers=headers)
-          with urllib.request.urlopen(req) as r:
-          import json as _j; return _j.load(r)
-          deadline=time.time()+1200
+              url = "https://api.github.com/" + path
+              if params:
+                  url += "?" + urllib.parse.urlencode(params)
+              req = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(req) as r:
+                  import json as _j
+                  return _j.load(r)
+          deadline = time.time() + 1200
           while True:
-          runs=api(f"repos/{repo}/actions/runs", {"head_sha": sha, "per_page": 100}).get("workflow_runs",[])
-          pending=False
-          for t in targets:
-          st=[r["status"] for r in runs if r["name"]==t]
-          if any(s in ("queued","in_progress","requested","waiting") for s in st):
-          pending=True; break
-          if not pending or time.time()>deadline: break
-          time.sleep(15)
+              runs = api(f"repos/{repo}/actions/runs", {"head_sha": sha, "per_page": 100}).get("workflow_runs", [])
+              pending = False
+              for t in targets:
+                  st = [r["status"] for r in runs if r["name"] == t]
+                  if any(s in ("queued", "in_progress", "requested", "waiting") for s in st):
+                      pending = True
+                      break
+              if not pending or time.time() > deadline:
+                  break
+              time.sleep(15)
           PY
       - name: Download and unpack logs
         run: |

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -208,3 +208,20 @@ GitHub Actions reported `Invalid workflow file` because line 22 in `.github/work
 
 ## Logs
 - No log file was generated; the workflow failed before execution.
+
+---
+
+## Failing workflows
+- **collect-logs** workflow (collect job)
+
+## Summary
+Python script in the "Wait for all workflows to finish for this SHA" step raised
+`IndentationError: expected an indented block after function definition` on line
+9, stopping the job before log collection could begin.
+
+## Fix
+- Indent the body of the `api` function and subsequent loop so the script runs
+  without syntax errors.
+
+## Logs
+- No log file was generated; the workflow failed before execution.


### PR DESCRIPTION
## Summary
- fix indentation in collect-logs wait step Python script
- document collect-logs workflow failure in triage

## Root Cause
- the `api` helper in `.github/workflows/collect-logs.yml` lacked an indented body, triggering `IndentationError` before the job waited for workflows

## Fix
- indent the body of the `api` function and subsequent loop in the wait step
- append triage note for the collect-logs failure

## Repro Steps
- run the **collect-logs** workflow and observe the `IndentationError` in the "Wait for all workflows to finish" step

## Risk
- low: only affects the log-collection workflow and adds documentation

## Links
- `ci-logs/latest` (not generated due to workflow failure)


------
https://chatgpt.com/codex/tasks/task_e_68aba965fa9083338a5d215ee3b9c3fb