### PR TITLE
ci: use $GITHUB_OUTPUT in collect logs

### DIFF
--- a/.github/workflows/collect-logs.yml
+++ b/.github/workflows/collect-logs.yml
@@ -38,10 +38,13 @@ jobs:
         id: targets
         run: |
           python3 - <<'PY'
-          import os, json
-          it=os.environ.get("INPUT_TARGETS","").strip()
-          envt=os.environ.get("TARGETS","[]").strip()
-          print(f"::set-output name=list::{it if it else envt}")
+          import os
+
+          it = os.environ.get("INPUT_TARGETS", "").strip()
+          envt = os.environ.get("TARGETS", "[]").strip()
+          value = it if it else envt
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"list={value}\n")
           PY
       - name: Wait for all workflows to finish for this SHA (only on workflow_run)
         if: ${{ github.event_name == 'workflow_run' }}

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -225,3 +225,20 @@ Python script in the "Wait for all workflows to finish for this SHA" step raised
 
 ## Logs
 - No log file was generated; the workflow failed before execution.
+
+---
+
+## Failing workflows
+- **collect-logs** workflow (collect job)
+
+## Summary
+The "Resolve targets" step invoked the deprecated `set-output` command,
+which now errors out and stops the job before collecting logs.
+
+## Fix
+- Write the resolved target list to `$GITHUB_OUTPUT` instead of using the
+  deprecated command.
+
+## Logs
+- No log file was generated; the workflow failed before execution.
+


### PR DESCRIPTION
## Summary
Fix collect-logs workflow failing due to deprecated `set-output` command.

## Root Cause
`Resolve targets` step used the removed `set-output` syntax, causing the job to exit before running.

## Fix
- Write targets to `$GITHUB_OUTPUT`.
- Record triage note for the failure.

## Repro Steps
- Trigger **collect-logs** workflow via `workflow_dispatch`.

## Risk
Low: workflow logic otherwise unchanged.

## Links
- No log file was generated; the workflow failed before execution.


------
https://chatgpt.com/codex/tasks/task_e_68ac4e4d17b483338e1347b31d806b17