### PR TITLE
ci: fix collect logs workflow

### DIFF
--- a/.github/workflows/collect-logs.yml
+++ b/.github/workflows/collect-logs.yml
@@ -38,10 +38,13 @@ jobs:
         id: targets
         run: |
           python3 - <<'PY'
-          import os, json
-          it=os.environ.get("INPUT_TARGETS","").strip()
-          envt=os.environ.get("TARGETS","[]").strip()
-          print(f"::set-output name=list::{it if it else envt}")
+          import os
+
+          it = os.environ.get("INPUT_TARGETS", "").strip()
+          envt = os.environ.get("TARGETS", "[]").strip()
+          value = it if it else envt
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"list={value}\n")
           PY
       - name: Wait for all workflows to finish for this SHA (only on workflow_run)
         if: ${{ github.event_name == 'workflow_run' }}
@@ -88,33 +91,57 @@ jobs:
           "X-GitHub-Api-Version": "2022-11-28",
           "User-Agent": "gha-log-collector"}
           def api_json(path, params=None):
-          url="https://api.github.com/"+path
-          if params: url += "?"+urllib.parse.urlencode(params)
-          req=urllib.request.Request(url, headers=headers)
-          with urllib.request.urlopen(req) as r:
-          import json as _j; return _j.load(r)
+              url = "https://api.github.com/" + path
+              if params:
+                  url += "?" + urllib.parse.urlencode(params)
+              req = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(req) as r:
+                  import json as _j
+                  return _j.load(r)
+
           def api_bytes(path):
-          url="https://api.github.com/"+path
-          req=urllib.request.Request(url, headers=headers)
-          with urllib.request.urlopen(req) as r:
-          return r.read()
-          runs=api_json(f"repos/{repo}/actions/runs", {"head_sha": sha, "per_page": 100}).get("workflow_runs",[])
-          tmp="ci-logs/_tmp"
+              url = "https://api.github.com/" + path
+              req = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(req) as r:
+                  return r.read()
+
+          runs = api_json(
+              f"repos/{repo}/actions/runs",
+              {"head_sha": sha, "per_page": 100},
+          ).get("workflow_runs", [])
+          tmp = "ci-logs/_tmp"
           shutil.rmtree("ci-logs/latest", ignore_errors=True)
           shutil.rmtree(tmp, ignore_errors=True)
           os.makedirs(tmp, exist_ok=True)
           for t in targets:
-          cand=[r for r in runs if r["name"]==t and r["conclusion"] in ("success","failure","cancelled","timed_out","action_required","neutral","skipped")]
-          if not cand: continue
-          cand.sort(key=lambda r: r["run_number"], reverse=True)
-          rid=cand[0]["id"]
-          zbytes=api_bytes(f"repos/{repo}/actions/runs/{rid}/logs")
-          zpath=os.path.join(tmp, f"{t}-{rid}.zip")
-          with open(zpath,"wb") as f: f.write(zbytes)
-          outdir=os.path.join(tmp, t)
-          os.makedirs(outdir, exist_ok=True)
-          with zipfile.ZipFile(zpath) as z: z.extractall(outdir)
-          os.remove(zpath)
+              cand = [
+                  r
+                  for r in runs
+                  if r["name"] == t
+                  and r["conclusion"]
+                  in (
+                      "success",
+                      "failure",
+                      "cancelled",
+                      "timed_out",
+                      "action_required",
+                      "neutral",
+                      "skipped",
+                  )
+              ]
+              if not cand:
+                  continue
+              cand.sort(key=lambda r: r["run_number"], reverse=True)
+              rid = cand[0]["id"]
+              zbytes = api_bytes(f"repos/{repo}/actions/runs/{rid}/logs")
+              zpath = os.path.join(tmp, f"{t}-{rid}.zip")
+              with open(zpath, "wb") as f:
+                  f.write(zbytes)
+              outdir = os.path.join(tmp, t)
+              os.makedirs(outdir, exist_ok=True)
+              with zipfile.ZipFile(zpath) as z:
+                  z.extractall(outdir)
+              os.remove(zpath)
           shutil.move(tmp, "ci-logs/latest")
           PY
       - name: Commit and push

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -215,6 +215,23 @@ GitHub Actions reported `Invalid workflow file` because line 22 in `.github/work
 - **collect-logs** workflow (collect job)
 
 ## Summary
+Python script in the "Download and unpack logs" step raised
+`IndentationError: expected an indented block after function definition` on
+line 9, preventing the job from fetching workflow logs.
+
+## Fix
+- Indent the helper functions and loop in the script so Python executes
+  without syntax errors.
+
+## Logs
+- No log file was generated; the workflow failed before execution.
+
+---
+
+## Failing workflows
+- **collect-logs** workflow (collect job)
+
+## Summary
 Python script in the "Wait for all workflows to finish for this SHA" step raised
 `IndentationError: expected an indented block after function definition` on line
 9, stopping the job before log collection could begin.
@@ -225,3 +242,20 @@ Python script in the "Wait for all workflows to finish for this SHA" step raised
 
 ## Logs
 - No log file was generated; the workflow failed before execution.
+
+---
+
+## Failing workflows
+- **collect-logs** workflow (collect job)
+
+## Summary
+The "Resolve targets" step invoked the deprecated `set-output` command,
+which now errors out and stops the job before collecting logs.
+
+## Fix
+- Write the resolved target list to `$GITHUB_OUTPUT` instead of using the
+  deprecated command.
+
+## Logs
+- No log file was generated; the workflow failed before execution.
+


### PR DESCRIPTION
## Summary
Fix collect-logs workflow failure from missing indentation in log download step.

## Root Cause
Python snippet in `.github/workflows/collect-logs.yml` defined helper functions without indenting their bodies, causing an `IndentationError` before any logs were fetched.

## Fix
- Indent helper functions and loop in log download script.
- Record triage note for the failure.

## Repro Steps
- Trigger **collect-logs** workflow via `workflow_dispatch`.

## Risk
Low: workflow logic otherwise unchanged.

## Links
- No log file was generated; the workflow failed before execution.


------
https://chatgpt.com/codex/tasks/task_e_68ac4e4d17b483338e1347b31d806b17