### PR TITLE
ci: trigger log aggregator on push

### DIFF
--- a/.github/workflows/collect-logs.yml
+++ b/.github/workflows/collect-logs.yml
@@ -1,8 +1,7 @@
 name: Collect all workflow logs
 on:
-  workflow_run:
-    workflows: []
-    types: [completed]
+  push:
+    branches: [dev, main]
   workflow_dispatch:
     inputs:
       sha:
@@ -18,7 +17,6 @@ concurrency:
 jobs:
   collect:
     runs-on: ubuntu-latest
-    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository) }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OWNER_REPO: ${{ github.repository }}
@@ -58,8 +56,7 @@ jobs:
           PY
       - name: Export target list to env
         run: echo "TARGETS=${{ steps.targets.outputs.list }}" >> "$GITHUB_ENV"
-      - name: Wait for all workflows to finish for this SHA (only on workflow_run)
-        if: ${{ github.event_name == 'workflow_run' }}
+      - name: Wait for all workflows to finish
         run: |
           python3 - <<'PY'
           import os, json, urllib.request, urllib.parse, time


### PR DESCRIPTION
## Summary
- trigger log aggregation on push to dev and main
- dynamically resolve workflows and wait for completion before collecting logs

## Testing
- `pre-commit run --files .github/workflows/collect-logs.yml` (command not found)
- `pytest -q` (pytest-cov argument missing)


------
https://chatgpt.com/codex/tasks/task_e_68ae1b262358833390be572b8781bd53