### PR TITLE
ci: fix collect logs workflow context

### DIFF
--- a/.github/workflows/collect-logs.yml
+++ b/.github/workflows/collect-logs.yml
@@ -17,7 +17,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: collect-logs-${{ github.ref_name }}-${{ inputs.sha || github.sha }}
+  group: collect-logs-${{ github.ref_name }}-${{ github.event.inputs.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OWNER_REPO: ${{ github.repository }}
-      HEAD_SHA: ${{ inputs.sha || github.sha }}
+      HEAD_SHA: ${{ github.event.inputs.sha || github.sha }}
       HEAD_BRANCH: ${{ github.ref_name }}
 
     steps:

--- a/docs/ci-triage.md
+++ b/docs/ci-triage.md
@@ -272,3 +272,20 @@ remote branch contained new commits, making the push non-fast-forward.
 
 ## Logs
 - No log file was generated; the workflow failed before execution.
+
+---
+
+## Failing workflows
+- **collect-logs** workflow (collect job)
+
+## Summary
+The workflow referenced `inputs.sha` in the concurrency group and job environment.
+On push events, the `inputs` context is unavailable, producing `Invalid workflow file`
+errors before execution.
+
+## Fix
+- Use `github.event.inputs.sha` with a fallback to `github.sha` for the concurrency
+  group and `HEAD_SHA` environment variable.
+
+## Logs
+- No log file was generated; the workflow failed before execution.


### PR DESCRIPTION
# Summary
- handle missing `inputs` context in collect-logs workflow
- note failure in CI triage log

# Root Cause
- `.github/workflows/collect-logs.yml` referenced `inputs.sha` which is undefined for push events, causing an invalid workflow file error.

# Fix
- use `github.event.inputs.sha` with `github.sha` fallback for concurrency group and `HEAD_SHA`
- record triage in `docs/ci-triage.md`

# Repro Steps
- push to `main` or `dev` so the collect-logs workflow loads; prior runs failed with `Invalid workflow file` before job execution

# Risk
- low: updates only reference expressions; no runtime logic change

# Links
- no log file generated; workflow failed before execution

------
https://chatgpt.com/codex/tasks/task_e_68b0c06fe86883338bd8051c162b10b1