### PR TITLE
ci(compose): unify DB creds + correct wait-for-it (no runtime change)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Prepare .env.ci
         shell: bash
         run: |
-          printf "PG_HOST=postgres\nPG_PORT=5432\nPG_USER=%s\nPG_PASSWORD=%s\nPG_DATABASE=%s\nPOSTGRES_HOST=postgres\nPOSTGRES_PORT=5432\nPOSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nPOSTGRES_DB=%s\n" "${{ secrets.PG_USER || 'postgres' }}" "${{ secrets.PG_PASSWORD || 'postgres' }}" "${{ secrets.PG_DATABASE || 'awa' }}" "${{ secrets.PG_USER || 'postgres' }}" "${{ secrets.PG_PASSWORD || 'postgres' }}" "${{ secrets.PG_DATABASE || 'awa' }}" > .env.ci
+          printf "PG_HOST=postgres\nPG_PORT=5432\nPG_USER=%s\nPG_PASSWORD=%s\nPG_DATABASE=%s\nPOSTGRES_HOST=postgres\nPOSTGRES_PORT=5432\nPOSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nPOSTGRES_DB=%s\nDATABASE_URL=postgresql://%s:%s@postgres:5432/%s\n" "${{ secrets.PG_USER || 'postgres' }}" "${{ secrets.PG_PASSWORD || 'pass' }}" "${{ secrets.PG_DATABASE || 'awa' }}" "${{ secrets.PG_USER || 'postgres' }}" "${{ secrets.PG_PASSWORD || 'pass' }}" "${{ secrets.PG_DATABASE || 'awa' }}" "${{ secrets.PG_USER || 'postgres' }}" "${{ secrets.PG_PASSWORD || 'pass' }}" "${{ secrets.PG_DATABASE || 'awa' }}" > .env.ci
 
       - name: Build images
         shell: bash
@@ -227,6 +227,19 @@ jobs:
           set -o pipefail
           docker compose $COMPOSE_FILES --env-file .env.ci up -d --wait 2>&1 | tee compose-up.txt
           exit ${PIPESTATUS[0]}
+
+      - name: Debug container env
+        if: always()
+        shell: bash
+        run: |
+          COMPOSE_FILES=""
+          [ -f docker-compose.yml ] && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.yml"
+          [ -f docker-compose.ci.yml ] && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.ci.yml"
+          [ -f docker-compose.postgres.yml ] && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.postgres.yml"
+          for svc in api etl celery_worker; do
+            echo "=== $svc ==="
+            docker compose $COMPOSE_FILES --env-file .env.ci exec -T "$svc" env | grep -E 'PG_|DATABASE_URL' || true
+          done
 
       - name: Dump compose logs
         if: always()

--- a/services/etl/entrypoint.sh
+++ b/services/etl/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-./wait-for-it.sh "${PG_HOST:-postgres}:${PG_PORT:-5432}" --timeout=30
+./wait-for-it.sh "${PG_HOST:-postgres}:${PG_PORT:-5432}" -t 30 -- true
 
 if [ "$#" -gt 0 ]; then
   exec "$@"


### PR DESCRIPTION
## Summary
Fix integration compose wait-for-it and align default DB credentials so CI no longer trips on missing password or misordered arguments.

## Root Cause
- `services/etl/entrypoint.sh` invoked `wait-for-it.sh` with `--timeout=30` before specifying the command, causing `exec: --timeout=30 not found` and preventing the container from waiting for Postgres.
- `.github/workflows/ci.yml` populated `PG_PASSWORD`/`POSTGRES_PASSWORD` with default `postgres`, while compose services used `pass`, leading to `password authentication failed`.

## Fix
- call `wait-for-it.sh` with host:port first and a dummy command.
- default `PG_PASSWORD`/`POSTGRES_PASSWORD` to `pass` and append `DATABASE_URL` accordingly.
- add optional debug step to print container PG_* vars and `DATABASE_URL`.

## Repro Steps
- `pytest -m "not integration"`
- CI integration job: `docker compose ... up` followed by tests.

## Risk
- Minimal: only CI scripts and entrypoint invocation adjusted; runtime logic untouched.

## Links
- `ci-logs/latest/compose-up.txt`
- `ci-logs/latest/compose-logs.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bf025e49448333a81fc141ba93d2cf